### PR TITLE
Lese fra offset 0 for annullert og forkortet topic

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/tilskuddsperiode/TilskuddsperiodeKafkaLytter.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/tilskuddsperiode/TilskuddsperiodeKafkaLytter.kt
@@ -24,13 +24,23 @@ class TilskuddsperiodeKafkaLytter(val service: RefusjonService, val objectMapper
         service.opprettRefusjon(godkjentMelding)
     }
 
-    @KafkaListener(topics = [Topics.TILSKUDDSPERIODE_ANNULLERT])
+    @KafkaListener(
+        topics = [Topics.TILSKUDDSPERIODE_ANNULLERT],
+        topicPartitions = [
+            TopicPartition(topic = Topics.TILSKUDDSPERIODE_ANNULLERT, partitionOffsets = [PartitionOffset(partition = "0", initialOffset = "0")])
+        ]
+    )
     fun tilskuddsperiodeAnnullert(tilskuddMelding: String) {
         val annullertMelding = objectMapper.readValue(tilskuddMelding, TilskuddsperiodeAnnullertMelding::class.java)
         service.annullerRefusjon(annullertMelding)
     }
 
-    @KafkaListener(topics = [Topics.TILSKUDDSPERIODE_FORKORTET])
+    @KafkaListener(
+        topics = [Topics.TILSKUDDSPERIODE_FORKORTET],
+        topicPartitions = [
+            TopicPartition(topic = Topics.TILSKUDDSPERIODE_FORKORTET, partitionOffsets = [PartitionOffset(partition = "0", initialOffset = "0")])
+        ]
+    )
     fun tilskuddsperiodeForkortet(tilskuddMelding: String) {
         val forkortetMelding = objectMapper.readValue(tilskuddMelding, TilskuddsperiodeForkortetMelding::class.java)
         service.forkortRefusjon(forkortetMelding)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
-      group-id: "tiltak-refusjon-api-2"
+      group-id: "tiltak-refusjon-api-3"
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 


### PR DESCRIPTION
Oppdatert de resterende kafka-lytterne for tilskuddsperiode annullert og forkortet til å lese fra offset 0.
Usikker på om det trengs å byttes group-id. Samtidig så er jo de lytterne også over på den nye group-iden..