### PR TITLE
Ny kolonne inntektslinje er_opptjent_i_periode

### DIFF
--- a/src/main/resources/db/migration/V26__refunderingsflagg_inntekter.sql
+++ b/src/main/resources/db/migration/V26__refunderingsflagg_inntekter.sql
@@ -1,1 +1,6 @@
 alter table inntektslinje add column er_opptjent_i_periode boolean default null;
+update inntektslinje set er_opptjent_i_periode = true where id in (
+        select i.id from inntektslinje i
+        inner join refusjonsgrunnlag rg on rg.inntektsgrunnlag_id = i.inntektsgrunnlag_id
+        inner join refusjon r on r.refusjonsgrunnlag_id = rg.id
+        where r.godkjent_av_arbeidsgiver is not null);

--- a/src/main/resources/db/migration/V26__refunderingsflagg_inntekter.sql
+++ b/src/main/resources/db/migration/V26__refunderingsflagg_inntekter.sql
@@ -1,6 +1,8 @@
 alter table inntektslinje add column er_opptjent_i_periode boolean default null;
-update inntektslinje set er_opptjent_i_periode = true where id in (
-        select i.id from inntektslinje i
-        inner join refusjonsgrunnlag rg on rg.inntektsgrunnlag_id = i.inntektsgrunnlag_id
-        inner join refusjon r on r.refusjonsgrunnlag_id = rg.id
-        where r.godkjent_av_arbeidsgiver is not null);
+update inntektslinje i set er_opptjent_i_periode = true where i.id in (
+    select i.id from inntektslinje i
+    inner join refusjonsgrunnlag rg on rg.inntektsgrunnlag_id = i.inntektsgrunnlag_id
+    inner join refusjon r on r.refusjonsgrunnlag_id = rg.id
+    where r.godkjent_av_arbeidsgiver is not null)
+    and i.beskrivelse in ('fastloenn', 'timeloenn', 'fastTillegg')
+    and i.inntekt_type = 'LOENNSINNTEKT';

--- a/src/main/resources/db/migration/V26__refunderingsflagg_inntekter.sql
+++ b/src/main/resources/db/migration/V26__refunderingsflagg_inntekter.sql
@@ -1,0 +1,1 @@
+alter table inntektslinje add column er_opptjent_i_periode boolean default null;


### PR DESCRIPTION
Foreslår å kjøre opprettelse av ny kolonne med flyway som en egen operasjon for å kunne holde dev og prod flyway i sync uanvhengig man vil teste endringene litt i dev først.

Legger på migrering av tidligere inntektslinjer som hører til refusjoner som er godkjente og setter de til opptjent i perioden for å gjøre visningen riktig for disse.

Bør kanskje ta en diskusjon om vi ønsker å gjøre denne migreringen, eller om det da blir seende ut som de har tatt valg de ikke har tatt.