### PR TITLE
Frigjøre midler ved utgått refusjon

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -182,6 +182,13 @@ class Refusjon(
             registerEvent(RefusjonKlar(this))
         }
     }
+    fun gjørRefusjonUtgått() {
+        krevStatus(RefusjonStatus.KLAR_FOR_INNSENDING)
+        if (Now.localDate().isAfter(fristForGodkjenning)) {
+            status = RefusjonStatus.UTGÅTT
+            registerEvent(RefusjonUtgått(this))
+        }
+    }
 
     fun forkort(tilskuddTom: LocalDate, tilskuddsbeløp: Int) {
         oppdaterStatus()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/StatusJobb.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/StatusJobb.kt
@@ -49,7 +49,7 @@ class StatusJobb(
         refusjoner.forEach {
             try {
                 if (Now.localDate().isAfter(it.fristForGodkjenning)) {
-                    it.status = RefusjonStatus.UTGÅTT
+                    it.gjørRefusjonUtgått()
                     antallEndretTilUtgått++
                     refusjonRepository.save(it)
                 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonUtgått.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonUtgått.kt
@@ -1,0 +1,5 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
+
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
+
+data class RefusjonUtgått(val refusjon: Refusjon)

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonTest.kt
@@ -151,6 +151,22 @@ internal class RefusjonTest {
     }
 
     @Test
+    fun `sett stauts til UTGÅTT`() {
+        // Nå klar for innsending
+        val refusjon = enRefusjon(
+            etTilskuddsgrunnlag().copy(
+                tilskuddFom = Now.localDate().minusMonths(1),
+                tilskuddTom = Now.localDate().minusDays(1)
+            )
+        )
+        Now.fixedDate(LocalDate.now().plusMonths(3))
+        //Frist skal nå bli utgått ved neste sjekk
+        refusjon.gjørRefusjonUtgått()
+        assertThat(refusjon.status).isEqualTo(RefusjonStatus.UTGÅTT)
+        Now.resetClock()
+    }
+
+    @Test
     fun `oppdater status til FOR_TIDLIG`() {
         val refusjon = enRefusjon(
             etTilskuddsgrunnlag().copy(


### PR DESCRIPTION
Når statusjobben endrer status på en refusjon til `UTGÅTT` sendes det også melding på topic `tilskuddsperiode-annullert`, slik at midler frigjøres.