### PR TITLE
ta bort subject i kall mot altinn-retttigheter-proxy med påvegenav token

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/altinn/AltinnTilgangsstyringService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/altinn/AltinnTilgangsstyringService.kt
@@ -20,24 +20,24 @@ class AltinnTilgangsstyringService(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun hentTilganger(fnr: String): Set<Organisasjon> {
+    fun hentTilganger(): Set<Organisasjon> {
         val organisasjoner = HashSet<Organisasjon>()
         var merÅHente = true
-        var i = 0;
+        var i = 0
         while (merÅHente) {
             val skip = altinnTilgangsstyringProperties.antall * i++
             logger.info("Henter organisasjoner fra Altinn, skip: $skip")
-            val nyeOrg = hentFraAltinn(fnr, skip)
+            val nyeOrg = hentFraAltinn(skip)
             organisasjoner.addAll(nyeOrg)
             merÅHente = nyeOrg.size >= altinnTilgangsstyringProperties.antall
         }
         return organisasjoner
     }
 
-    private fun hentFraAltinn(fnr: String, skip: Int): Set<Organisasjon> {
+    private fun hentFraAltinn(skip: Int): Set<Organisasjon> {
         try {
             return restTemplate.exchange(
-                lagAltinnUrl(fnr, skip),
+                lagAltinnUrl(skip),
                 HttpMethod.GET,
                 getAuthHeadersForAltinn(),
                 Array<Organisasjon>::class.java).body?.toSet()
@@ -48,10 +48,9 @@ class AltinnTilgangsstyringService(
         }
     }
 
-    private fun lagAltinnUrl(fnr: String, skip: Int): URI {
+    private fun lagAltinnUrl(skip: Int): URI {
         return UriComponentsBuilder.fromUri(altinnTilgangsstyringProperties.uri)
             .queryParam("ForceEIAuthentication")
-            .queryParam("subject", fnr)
             .queryParam("serviceCode", altinnTilgangsstyringProperties.serviceCode)
             .queryParam("serviceEdition", altinnTilgangsstyringProperties.serviceEdition)
             .queryParam("\$top", altinnTilgangsstyringProperties.antall)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
@@ -14,7 +14,6 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
-import java.time.Instant
 
 
 data class InnloggetArbeidsgiver(
@@ -29,7 +28,7 @@ data class InnloggetArbeidsgiver(
     @JsonIgnore
     val log: Logger = LoggerFactory.getLogger(javaClass)
 
-    val organisasjoner: Set<Organisasjon> = altinnTilgangsstyringService.hentTilganger(identifikator)
+    val organisasjoner: Set<Organisasjon> = altinnTilgangsstyringService.hentTilganger()
 
     fun finnAlleMedBedriftnummer(bedriftnummer: String): List<Refusjon> {
         sjekkHarTilgangTilRefusjonerForBedrift(bedriftnummer)


### PR DESCRIPTION
Altinn rettigheter proxy forkaster subject da fnr [hentes fra pid claim i token](https://github.com/navikt/altinn-rettigheter-proxy/blob/master/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt#L115)
Det logges også en warning av typen: `Request inneholder subject (fødselsnummer). Dette burde forhindres av personvernshensyn, da det logges av andre systemer.` ref: https://logs.adeo.no/goto/46dcfe10-2438-11ed-a503-d3f90a22c586

Vi gjorde et lite forsøk på å fjerne fnr helt i denne PR, men ser at det påvirker tester, lokal kjøring og labs.
Lager derfor denne PR med kun fjerning av fnr fra selve kallet til diskusjon. Testene kjører ikke på PRer ser det ut som, så den bør nok ikke merges selv om den er "grønn".

Hvordan tenker dere er beste måten å gå videre her? Vi bistår gjerne.

PS
Altinn rettigheter proxy returnerer nå [tom liste dersom brukeren ikke har profil i altinn](https://github.com/navikt/altinn-rettigheter-proxy/blob/master/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/altinn/AltinnClient.kt#L85-L88). 

