### PR TITLE
Hent 1 mnd inntekter

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -67,7 +67,14 @@ class RefusjonService(
             return
         }
 
-        val antallMånederSomSkalSjekkes: Long = if (refusjon.unntakOmInntekterToMånederFrem) 2 else 1
+
+        //var antallMånederSomSkalSjekkes: Long = if (refusjon.unntakOmInntekterToMånederFrem) 2 else if (refusjon.tilskuddsgrunnlag.tiltakstype === Tiltakstype.SOMMERJOBB) 1 else 0
+        var antallMånederSomSkalSjekkes: Long = 0
+        if (refusjon.unntakOmInntekterToMånederFrem) {
+            antallMånederSomSkalSjekkes = 2
+        } else if (refusjon.tilskuddsgrunnlag.tiltakstype === Tiltakstype.SOMMERJOBB) {
+            antallMånederSomSkalSjekkes = 1
+        }
         try {
             val inntektsoppslag = inntektskomponentService.hentInntekter(
                 fnr = refusjon.deltakerFnr,

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -69,18 +69,18 @@ class RefusjonService(
 
 
         //var antallMånederSomSkalSjekkes: Long = if (refusjon.unntakOmInntekterToMånederFrem) 2 else if (refusjon.tilskuddsgrunnlag.tiltakstype === Tiltakstype.SOMMERJOBB) 1 else 0
-        var antallMånederSomSkalSjekkes: Long = 0
+        var antallEkstraMånederSomSkalSjekkes: Long = 0
         if (refusjon.unntakOmInntekterToMånederFrem) {
-            antallMånederSomSkalSjekkes = 2
+            antallEkstraMånederSomSkalSjekkes = 2
         } else if (refusjon.tilskuddsgrunnlag.tiltakstype === Tiltakstype.SOMMERJOBB) {
-            antallMånederSomSkalSjekkes = 1
+            antallEkstraMånederSomSkalSjekkes = 1
         }
         try {
             val inntektsoppslag = inntektskomponentService.hentInntekter(
                 fnr = refusjon.deltakerFnr,
                 bedriftnummerDetSøkesPå = refusjon.bedriftNr,
                 datoFra = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
-                datoTil = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom.plusMonths(antallMånederSomSkalSjekkes)
+                datoTil = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom.plusMonths(antallEkstraMånederSomSkalSjekkes)
             )
             val inntektsgrunnlag = Inntektsgrunnlag(
                 inntekter = inntektsoppslag.first,

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -67,8 +67,6 @@ class RefusjonService(
             return
         }
 
-
-        //var antallMånederSomSkalSjekkes: Long = if (refusjon.unntakOmInntekterToMånederFrem) 2 else if (refusjon.tilskuddsgrunnlag.tiltakstype === Tiltakstype.SOMMERJOBB) 1 else 0
         var antallEkstraMånederSomSkalSjekkes: Long = 0
         if (refusjon.unntakOmInntekterToMånederFrem) {
             antallEkstraMånederSomSkalSjekkes = 2

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
@@ -5,7 +5,10 @@ import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.*
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import no.nav.arbeidsgiver.tiltakrefusjon.varsling.VarselType
 import no.nav.arbeidsgiver.tiltakrefusjon.varsling.Varsling
+import java.time.LocalDate
 import java.time.YearMonth
+import java.time.temporal.TemporalAdjusters.*
+
 
 fun enRefusjon(tilskuddsgrunnlag: Tilskuddsgrunnlag = etTilskuddsgrunnlag()): Refusjon {
     val deltakerFnr = "07098142678"
@@ -67,7 +70,7 @@ fun refusjoner(): List<Refusjon> {
         kiellandNy,
         kiellandGammel,
         BjørnsonUtgått,
-        `Bjørnstjerne Bjørnson`(),
+        `Bjørnstjerne Bjørnson`().copy(tilskuddsgrunnlag = `Bjørnstjerne Bjørnson`().tilskuddsgrunnlag.copy(tiltakstype = Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD)),
         bjørnsonSendtKrav,
         `Nils Nilsen`(),
         `Inger Hagerup`(),
@@ -115,8 +118,8 @@ fun etTilskuddsgrunnlag() = Tilskuddsgrunnlag(
     feriepengerSats = 0.12,
     arbeidsgiveravgiftSats = 0.141,
     lønnstilskuddsprosent = 40,
-    tilskuddFom = Now.localDate().minusMonths(3).withDayOfMonth(1),
-    tilskuddTom = Now.localDate().minusMonths(1).withDayOfMonth(20),
+    tilskuddFom = Now.localDate().minusMonths(1).withDayOfMonth(1),
+    tilskuddTom = Now.localDate().minusMonths(1).with(lastDayOfMonth()),
     tilskuddsbeløp = 13579,
     avtaleNr = 3456,
     løpenummer = 3,

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
@@ -8,6 +8,7 @@ import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.MidlerFrigjortÅrsak
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeForkortetMelding
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeGodkjentMelding
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
+import no.nav.arbeidsgiver.tiltakrefusjon.varsling.VarslingRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -27,13 +28,16 @@ class RefusjonServiceTest(
     @Autowired
     val refusjonService: RefusjonService,
     @Autowired
-    val refusjonRepository: RefusjonRepository
+    val refusjonRepository: RefusjonRepository,
+    @Autowired
+    val varslingRepository: VarslingRepository
 ) {
     @SpykBean
     lateinit var inntektskomponentService: InntektskomponentService
 
     @BeforeEach
     fun setup() {
+        varslingRepository.deleteAll()
         refusjonRepository.deleteAll()
     }
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeForko
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeGodkjentMelding
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.springframework.beans.factory.annotation.Autowired
@@ -30,6 +31,11 @@ class RefusjonServiceTest(
 ) {
     @SpykBean
     lateinit var inntektskomponentService: InntektskomponentService
+
+    @BeforeEach
+    fun setup() {
+        refusjonRepository.deleteAll()
+    }
 
     @Test
     fun `oppretter, forkorter, og forlenger`() {


### PR DESCRIPTION
Gjort om til følgende regler:
henter 1 måned med inntekter som standard (den måneden som refusjonen gjelder for)
på sommerjobb hentes det likevel for måneden etter.