### PR TITLE
baserer maks forlengelse av frist på opprinnelig frist

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -247,9 +247,10 @@ class Refusjon(
             throw FeilkodeException(Feilkode.UGYLDIG_FORLENGELSE_AV_FRIST)
         }
 
-        // Satt midlertidig maks frist til 1 mnd etter tiltak
-        if (nyFrist > antallMånederEtter(refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom, 3)) {
-            // Kan maks forlenge 1 mnd ekstra fra opprinnelig frist på 2 mnd
+        // Opprinnelig frist er er 2 mnd. Det er enten 2 mnd etter tilskuddTom eller 2 mnd etter godkjentAvBeslutterTidspunkt.
+        // Maks forlengelse er 1 mnd.
+        val opprinneligFrist = lagFristForGodkjenning()
+        if (nyFrist > antallMånederEtter(opprinneligFrist, 1)) {
             throw FeilkodeException(Feilkode.FOR_LANG_FORLENGELSE_AV_FRIST)
         }
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonTest.kt
@@ -379,6 +379,28 @@ internal class RefusjonTest {
     }
 
     @Test
+    internal fun `forlengelse av frist skal kunne gjøres 3 måned etter godkjentAvBeslutter hvis den ble godkjent etter tilskuddTom`() {
+        val refusjon = enRefusjon(
+            etTilskuddsgrunnlag().copy(
+                tilskuddFom = Now.localDate().minusMonths(2).minusDays(1),
+                tilskuddTom = Now.localDate().minusMonths(1).minusDays(1),
+                godkjentAvBeslutterTidspunkt = Now.localDateTime()
+            )
+        )
+        val godkjentAvBeslutterTidspunkt = refusjon.tilskuddsgrunnlag.godkjentAvBeslutterTidspunkt.toLocalDate()
+        val sisteDagDetErMuligÅForlengeTil = antallMånederEtter(godkjentAvBeslutterTidspunkt, 3)
+
+        assertFeilkode(Feilkode.FOR_LANG_FORLENGELSE_AV_FRIST) {
+            refusjon.forlengFrist(sisteDagDetErMuligÅForlengeTil.plusDays(1), "", "")
+        }
+
+        // Positiv test
+        refusjon.forlengFrist(sisteDagDetErMuligÅForlengeTil, "", "")
+        assertThat(refusjon.fristForGodkjenning).isEqualTo(sisteDagDetErMuligÅForlengeTil)
+        assertThat(refusjon.forrigeFristForGodkjenning).isEqualTo(antallMånederEtter(refusjon.tilskuddsgrunnlag.godkjentAvBeslutterTidspunkt.toLocalDate(), 2))
+    }
+
+    @Test
     internal fun `godkjent tilskuddsperiode som er ferdig før den godkjennes får 2mnd frist`() {
         val iDag = LocalDate.now()
         val tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(


### PR DESCRIPTION
Baserer maks forlengelse av frist på opprinnelig frist.
Opprinnelig frist har tidligere vært 2 måneder etter tilskuddTom. Det er endret, slik at om beslutter godkjenner tilskuddsperioden etter at tilskuddsperioden er ferdig, blir fristen satt 2 måneder etter godkjentAvBeslutterTidspunkt.

Dette må taes høyde for i reglene for forlengelse av frister, hvor man maks skal kunne forlenge 1 måned.