### PR TITLE
Godkjent null belop

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -170,15 +170,12 @@ class Refusjon(
         godkjentAvArbeidsgiver = Now.instant()
         status = RefusjonStatus.SENDT_KRAV
 
-        // Hva om beløp er eksakt 0 kr? Skal vi annullere da? Må vel det.. Men trenger ikke lagre et minusbeløp til neste
-
         if(refusjonsgrunnlag.refusjonsgrunnlagetErNullSomIZero()) {
             status = RefusjonStatus.GODKJENT_NULLBELØP
-            registerEvent(RefusjonGodkjentNullBeløp(this, utførtAv)) // Denne annullerer
+            registerEvent(RefusjonGodkjentNullBeløp(this, utførtAv))
         } else if(!refusjonsgrunnlag.refusjonsgrunnlagetErPositivt()) {
             status = RefusjonStatus.GODKJENT_MINUSBELØP
-            // Her bør det vel annulleres? Og ikke sende minus-ordre til oebs. Det vil de ikke ha..
-            registerEvent(RefusjonGodkjentMinusBeløp(this, utførtAv)) // Denne annullerer
+            registerEvent(RefusjonGodkjentMinusBeløp(this, utførtAv))
         } else {
             registerEvent(GodkjentAvArbeidsgiver(this, utførtAv))
         }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -169,12 +169,20 @@ class Refusjon(
         }
         godkjentAvArbeidsgiver = Now.instant()
         status = RefusjonStatus.SENDT_KRAV
-        if(!refusjonsgrunnlag.refusjonsgrunnlagetErPositivt()) {
+
+        // Hva om beløp er eksakt 0 kr? Skal vi annullere da? Må vel det.. Men trenger ikke lagre et minusbeløp til neste
+
+        if(refusjonsgrunnlag.refusjonsgrunnlagetErNullSomIZero()) {
+            status = RefusjonStatus.GODKJENT_NULLBELØP
+            registerEvent(RefusjonGodkjentNullBeløp(this, utførtAv)) // Denne annullerer
+        } else if(!refusjonsgrunnlag.refusjonsgrunnlagetErPositivt()) {
             status = RefusjonStatus.GODKJENT_MINUSBELØP
-            registerEvent(RefusjonMinusBeløp(this, utførtAv))
+            // Her bør det vel annulleres? Og ikke sende minus-ordre til oebs. Det vil de ikke ha..
+            registerEvent(RefusjonGodkjentMinusBeløp(this, utførtAv)) // Denne annullerer
+        } else {
+            registerEvent(GodkjentAvArbeidsgiver(this, utførtAv))
         }
 
-        registerEvent(GodkjentAvArbeidsgiver(this, utførtAv))
         registerEvent(RefusjonEndretStatus(this))
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonKafkaProducer.kt
@@ -119,11 +119,13 @@ class RefusjonKafkaProducer(
 
     @TransactionalEventListener
     fun refusjonGodkjentMinusBeløp(event: RefusjonGodkjentMinusBeløp) {
+        log.info("Godkjent refusjon ${event.refusjon.id} med minusbeløp, sender annullering")
         annullerTilskuddsperiodeEtterNullEllerMinusBeløp(event.refusjon.tilskuddsgrunnlag.tilskuddsperiodeId, MidlerFrigjortÅrsak.REFUSJON_MINUS_BELØP)
     }
 
     @TransactionalEventListener
     fun refusjonGodkjentNullBeløp(event: RefusjonGodkjentNullBeløp) {
+        log.info("Godkjent refusjon ${event.refusjon.id} med nullbeløp, sender annullering")
         annullerTilskuddsperiodeEtterNullEllerMinusBeløp(event.refusjon.tilskuddsgrunnlag.tilskuddsperiodeId, MidlerFrigjortÅrsak.REFUSJON_GODKJENT_NULL_BELØP)
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonKafkaProducer.kt
@@ -136,16 +136,15 @@ class RefusjonKafkaProducer(
             Topics.TILSKUDDSPERIODE_ANNULLERT,
             tilskuddsperiodeId,
             tilskuddperiodeAnnullertMelding
-        )
-            .addCallback({
-                log.info(
-                    "Melding med id {} sendt til Kafka topic {}",
-                    it?.producerRecord?.key(),
-                    it?.recordMetadata?.topic()
-                )
-            }, {
-                log.warn("Feil ved sending av tilskuddsperiode annullert melding på Kafka", it)
-            })
+        ).addCallback({
+            log.info(
+                "Melding med id {} sendt til Kafka topic {}",
+                it?.producerRecord?.key(),
+                it?.recordMetadata?.topic()
+            )
+        }, {
+            log.warn("Feil ved sending av tilskuddsperiode annullert melding på Kafka", it)
+        })
     }
 
     // En topic med alle statuser for en refusjon. Da kan den aggregeres av fager for å vise det de vil

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonStatus.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonStatus.kt
@@ -9,5 +9,6 @@ enum class RefusjonStatus {
     UTGÅTT,
     ANNULLERT,
     GODKJENT_MINUSBELØP,
-    UTBETALING_FEILET
+    UTBETALING_FEILET,
+    GODKJENT_NULLBELØP
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
@@ -95,6 +95,10 @@ class Refusjonsgrunnlag(
         return this.beregning?.refusjonsbeløp != null && this.beregning!!.refusjonsbeløp > 0
     }
 
+    fun refusjonsgrunnlagetErNullSomIZero(): Boolean {
+        return this.beregning?.refusjonsbeløp != null && this.beregning!!.refusjonsbeløp == 0
+    }
+
     private fun gjørBeregning(): Boolean {
         if (erAltOppgitt()) {
             this.beregning = beregnRefusjonsbeløp(

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonGodkjentMinusBeløp.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonGodkjentMinusBeløp.kt
@@ -1,0 +1,6 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
+
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
+
+data class RefusjonGodkjentMinusBeløp(override val refusjon: Refusjon, override val utførtAv: String = "System") :
+    SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonGodkjentNullBeløp.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonGodkjentNullBeløp.kt
@@ -2,5 +2,5 @@ package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
-data class RefusjonMinusBeløp(override val refusjon: Refusjon, override val utførtAv: String = "Kafka") :
+data class RefusjonGodkjentNullBeløp(override val refusjon: Refusjon, override val utførtAv: String = "System") :
     SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/tilskuddsperiode/TilskuddsperiodeAnnullertMelding.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/tilskuddsperiode/TilskuddsperiodeAnnullertMelding.kt
@@ -10,4 +10,5 @@ enum class MidlerFrigjortÅrsak {
     REFUSJON_FRIST_UTGÅTT,
     REFUSJON_MINUS_BELØP,
     REFUSJON_IKKE_SØKT,
+    REFUSJON_GODKJENT_NULL_BELØP
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonTest.kt
@@ -209,6 +209,20 @@ internal class RefusjonTest {
     }
 
     @Test
+    fun `oppdater status til GODKJENT_NULLBELØP`() {
+        val refusjon = enRefusjon(
+            etTilskuddsgrunnlag().copy(
+                tilskuddFom = Now.localDate().minusDays(2),
+                tilskuddTom = Now.localDate().minusDays(1),
+                tilskuddsbeløp = 0
+            )
+        ).medInntekterKunFraTiltaket().medInntektsgrunnlag()
+        refusjon.oppgiBedriftKontonummer("10000008145")
+        refusjon.godkjennForArbeidsgiver("12345678901")
+        assertThat(refusjon.status).isEqualTo(RefusjonStatus.GODKJENT_NULLBELØP)
+    }
+
+    @Test
     fun `oppdaterer ikke status hvis ANNULLERT`() {
 
         val refusjon = enRefusjon(


### PR DESCRIPTION
Håndterer to caser:
- Godkjent "nullbeløp".
- Fikser annullering til oebs ved godkjent minus-beløp.

Noen tilfelder kan en refusjon gå i "null". Enten ved trekk for f eks sykefravær, eller triksing av tilskuddsbeløpet. Ordren i oebs må da annulleres.