### PR TITLE
Deleter beregning og andre valg om man velger nei på alle inntektslinjer

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
@@ -136,6 +136,26 @@ class Refusjonsgrunnlag(
         }
         inntektslinje.erOpptjentIPeriode = erOpptjentIPeriode
 
+        var erNoenOpptjentIPerioden = false
+        inntektsgrunnlag?.inntekter?.forEach {
+            if(it.erOpptjentIPeriode == true) {
+                println("AAAAAAAAAAAAAAAAAAAAAAAAA ${it.id}")
+                erNoenOpptjentIPerioden = true
+            }
+        }
+
+        if(!erNoenOpptjentIPerioden) {
+            beregning = null
+            endretBruttoLønn = null
+            fratrekkRefunderbarBeløp = null
+            inntekterKunFraTiltaket = null
+            // Slett beregning
+            // Slett endret bruttolønn
+            // Slett sykefravær
+            println("FSEDDDDDDDDDDDD >>>>>>>>>>>>>>>>>>>>>> Returnal false")
+            return false
+        }
+
         return gjørBeregning()
     }
 


### PR DESCRIPTION
Nuller ut og sletter en del data, som f eks beregning, når man velger nei til alle inntektslinjer. Dette gjør at frontend kan vise riktigte komponenter basert på riktig data.