### PR TITLE
Unngå ny ID problem

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Inntektslinje.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Inntektslinje.kt
@@ -21,7 +21,7 @@ data class Inntektslinje(
     var erOpptjentIPeriode: Boolean? = null,
 ) {
     @Id
-    val id: String = ULID.random()
+    var id: String = ULID.random()
 
     @ManyToOne
     @JoinColumn(name = "inntektsgrunnlag_id")

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -281,7 +281,8 @@ class Refusjon(
             return false
         }
         return refusjonsgrunnlag.inntektsgrunnlag?.innhentetTidspunkt?.isBefore(
-            Now.localDateTime().minusMinutes(1)
+            Now.localDateTime().minusSeconds(10)
+            //Now.localDateTime().minusMinutes(1)
         ) ?: true
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -281,8 +281,7 @@ class Refusjon(
             return false
         }
         return refusjonsgrunnlag.inntektsgrunnlag?.innhentetTidspunkt?.isBefore(
-            Now.localDateTime().minusSeconds(10)
-            //Now.localDateTime().minusMinutes(1)
+            Now.localDateTime().minusMinutes(1)
         ) ?: true
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
@@ -44,8 +44,6 @@ class Refusjonsgrunnlag(
         val log = LoggerFactory.getLogger(javaClass)
         if (gjeldendeInntektsgrunnlag != null) {
             inntektsgrunnlag.inntekter.forEach { inntekt ->
-//                val gjeldendeInntektslinje = gjeldendeInntektsgrunnlag.inntekter
-//                    .find { it.beløp == inntekt.beløp && it.måned == inntekt.måned && it.beskrivelse == inntekt.beskrivelse }
                 val gjeldendeInntektslinje = finnInntektslinjeIListeMedInntekter(inntekt, gjeldendeInntektsgrunnlag.inntekter)
                 if (gjeldendeInntektslinje != null) {
                     inntekt.id = gjeldendeInntektslinje.id

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
@@ -46,6 +46,7 @@ class Refusjonsgrunnlag(
             inntektsgrunnlag.inntekter.forEach { inntekt ->
                 val gjeldendeInntektslinje = finnInntektslinjeIListeMedInntekter(inntekt, gjeldendeInntektsgrunnlag.inntekter)
                 if (gjeldendeInntektslinje != null) {
+                    // inntekt er identisk med en inntekt fra tidligere inntektsgrunnlag (gjeldendeInntektslinje)
                     inntekt.id = gjeldendeInntektslinje.id
                     inntekt.erOpptjentIPeriode = gjeldendeInntektslinje.erOpptjentIPeriode
                 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
@@ -42,9 +42,12 @@ class Refusjonsgrunnlag(
     ): Boolean {
         if (gjeldendeInntektsgrunnlag != null) {
             inntektsgrunnlag.inntekter.forEach { inntekt ->
-                val gjeldendeInntektslinje = gjeldendeInntektsgrunnlag.inntekter
-                    .find { it.beløp == inntekt.beløp && it.måned == inntekt.måned && it.beskrivelse == inntekt.beskrivelse }
+//                val gjeldendeInntektslinje = gjeldendeInntektsgrunnlag.inntekter
+//                    .find { it.beløp == inntekt.beløp && it.måned == inntekt.måned && it.beskrivelse == inntekt.beskrivelse }
+                val gjeldendeInntektslinje = finnInntektslinjeIListeMedInntekter(inntekt, gjeldendeInntektsgrunnlag.inntekter)
                 if (gjeldendeInntektslinje != null) {
+                    inntektsgrunnlag.inntekter.minusElement(inntekt)
+                    inntektsgrunnlag.inntekter.plusElement(gjeldendeInntektslinje)
                     inntekt.erOpptjentIPeriode = gjeldendeInntektslinje.erOpptjentIPeriode
                 }
             }
@@ -54,6 +57,17 @@ class Refusjonsgrunnlag(
         }
         this.inntektsgrunnlag = inntektsgrunnlag
         return gjørBeregning()
+    }
+
+    fun finnInntektslinjeIListeMedInntekter(linje1: Inntektslinje, inntektslinjer: Set<Inntektslinje>): Inntektslinje? {
+        return inntektslinjer.find {
+                    it.inntektType == linje1.inntektType &&
+                    it.beskrivelse == linje1.beskrivelse &&
+                    it.beløp == linje1.beløp &&
+                    it.måned == linje1.måned &&
+                    it.opptjeningsperiodeFom == linje1.opptjeningsperiodeFom &&
+                    it.opptjeningsperiodeTom == linje1.opptjeningsperiodeTom
+        }
     }
 
     fun oppgiForrigeRefusjonsbeløp(forrigeRefusjonMinusBeløp: Int): Boolean{

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
@@ -4,6 +4,7 @@ import com.github.guepardoapps.kulid.ULID
 import no.nav.arbeidsgiver.tiltakrefusjon.Feilkode
 import no.nav.arbeidsgiver.tiltakrefusjon.FeilkodeException
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
+import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.YearMonth
 import javax.persistence.CascadeType
@@ -40,14 +41,14 @@ class Refusjonsgrunnlag(
         inntektsgrunnlag: Inntektsgrunnlag,
         gjeldendeInntektsgrunnlag: Inntektsgrunnlag?
     ): Boolean {
+        val log = LoggerFactory.getLogger(javaClass)
         if (gjeldendeInntektsgrunnlag != null) {
             inntektsgrunnlag.inntekter.forEach { inntekt ->
 //                val gjeldendeInntektslinje = gjeldendeInntektsgrunnlag.inntekter
 //                    .find { it.beløp == inntekt.beløp && it.måned == inntekt.måned && it.beskrivelse == inntekt.beskrivelse }
                 val gjeldendeInntektslinje = finnInntektslinjeIListeMedInntekter(inntekt, gjeldendeInntektsgrunnlag.inntekter)
                 if (gjeldendeInntektslinje != null) {
-                    inntektsgrunnlag.inntekter.minusElement(inntekt)
-                    inntektsgrunnlag.inntekter.plusElement(gjeldendeInntektslinje)
+                    inntekt.id = gjeldendeInntektslinje.id
                     inntekt.erOpptjentIPeriode = gjeldendeInntektslinje.erOpptjentIPeriode
                 }
             }

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/IntegrasjonerMockServer.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/IntegrasjonerMockServer.kt
@@ -16,7 +16,7 @@ class IntegrasjonerMockServer(@Value("\${wiremock.port}") val wiremockPort: Int)
     private val server: WireMockServer = WireMockServer(WireMockConfiguration
         .options()
         .usingFilesUnderClasspath(".")
-        .notifier(ConsoleNotifier(true))
+        .notifier(ConsoleNotifier(false))
         .port(wiremockPort))
 
     init {


### PR DESCRIPTION
inntektslinjer får ny ID hver gang inntekter hentes. Dette er problematisk, hvis man huker av for opptjent i perioden samtidig som inntektene hentes.