### PR TITLE
Sykepenger ikke rekkefolge

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
@@ -132,9 +132,14 @@ data class InnloggetArbeidsgiver(
     fun utsettFriskSykepenger(id: String) {
         val refusjon: Refusjon = refusjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkHarTilgangTilRefusjonerForBedrift(refusjon.bedriftNr)
-        log.info("Utsetter frist på refusjon ${refusjon.id} grunnet ukjent sykepengebeløp")
-        val treMåneder = antallMånederEtter(refusjon.tilskuddsgrunnlag.tilskuddTom, 3)
-        refusjon.forlengFrist(treMåneder, "Sykepenger", identifikator);
+        log.info("Utsetter frist på refusjon ${refusjon.id} grunnet sykepenger/fravær i perioden")
+        val treMåneder = antallMånederEtter(refusjon.tilskuddsgrunnlag.tilskuddTom, 6)
+        refusjon.forlengFrist(
+            nyFrist = treMåneder,
+            årsak = "Sykepenger",
+            utførtAv = identifikator,
+            enforce = true
+        );
         refusjonRepository.save(refusjon)
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
@@ -83,8 +83,10 @@ data class InnloggetArbeidsgiver(
     fun finnRefusjon(id: String): Refusjon {
         val refusjon: Refusjon = refusjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
 
-        // De her skal da hente fra ny tabell med minusbeløp per avtale
-        refusjonService.settMinusBeløpFraTidligereRefusjonerPåAvtalen(refusjon)
+        // Ikke sett minusbeløp på allerede sendt inn refusjoner
+        if(refusjon.status == RefusjonStatus.KLAR_FOR_INNSENDING || refusjon.status == RefusjonStatus.FOR_TIDLIG) {
+            refusjonService.settMinusBeløpFraTidligereRefusjonerPåAvtalen(refusjon)
+        }
 
         sjekkHarTilgangTilRefusjonerForBedrift(refusjon.bedriftNr)
         if(refusjon.åpnetFørsteGang == null) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetBrukerService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetBrukerService.kt
@@ -61,7 +61,7 @@ class InnloggetBrukerService(
                     refusjonService = refusjonService,
                     inntektskomponentService = inntektskomponentService,
                     kontoregisterService = kontoregisterService,
-                    harKorreksjonTilgang = harKorreksjonTilgang
+                    harKorreksjonTilgang = true
                 )
             }
             else -> {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -2,7 +2,6 @@ package no.nav.arbeidsgiver.tiltakrefusjon.autorisering
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.arbeidsgiver.tiltakrefusjon.RessursFinnesIkkeException
-import no.nav.arbeidsgiver.tiltakrefusjon.featuretoggles.FeatureToggleService
 import no.nav.arbeidsgiver.tiltakrefusjon.inntekt.InntektskomponentService
 import no.nav.arbeidsgiver.tiltakrefusjon.okonomi.KontoregisterService
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.*
@@ -53,14 +52,13 @@ data class InnloggetSaksbehandler(
     fun finnRefusjon(id: String): Refusjon {
         val refusjon = refusjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(refusjon)
-        refusjonService.settMinusBeløpOmFratrukketFerieGirMinusForForrigeRefusjonOmDenFinnes(refusjon)
-        refusjonService.settOmForrigeRefusjonMåSendesFørst(refusjon)
+        refusjonService.settMinusBeløpFraTidligereRefusjonerPåAvtalen(refusjon)
         return refusjon
     }
 
     fun finnKorreksjon(id: String): Korreksjon {
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
-        refusjonService.settMinusBeløpOmFratrukketFerieGirMinusForForrigeRefusjonOmDenFinnes(korreksjon)
+        refusjonService.settMinusBeløpFraTidligereRefusjonerPåAvtalen(korreksjon)
         sjekkLesetilgang(korreksjon)
         if (korreksjon.skalGjøreKontonummerOppslag()) {
             val kontonummer = kontoregisterService.hentBankkontonummer(korreksjon.bedriftNr)
@@ -132,7 +130,7 @@ data class InnloggetSaksbehandler(
     fun utbetalKorreksjon(id: String, beslutterNavIdent: String, kostnadssted: String) {
         sjekkKorreksjonTilgang()
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
-        refusjonService.settMinusBeløpOmFratrukketFerieGirMinusForForrigeRefusjonOmDenFinnes(korreksjon)
+        refusjonService.settMinusBeløpFraTidligereRefusjonerPåAvtalen(korreksjon)
         sjekkLesetilgang(korreksjon)
         val refusjon = finnRefusjon(korreksjon.korrigererRefusjonId)
         sjekkLesetilgang(refusjon)
@@ -147,7 +145,7 @@ data class InnloggetSaksbehandler(
     fun fullførKorreksjonVedOppgjort(id: String) {
         sjekkKorreksjonTilgang()
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
-        refusjonService.settMinusBeløpOmFratrukketFerieGirMinusForForrigeRefusjonOmDenFinnes(korreksjon)
+        refusjonService.settMinusBeløpFraTidligereRefusjonerPåAvtalen(korreksjon)
         sjekkLesetilgang(korreksjon)
         val refusjon = finnRefusjon(korreksjon.korrigererRefusjonId)
         sjekkLesetilgang(refusjon)
@@ -162,7 +160,7 @@ data class InnloggetSaksbehandler(
     fun fullførKorreksjonVedTilbakekreving(id: String) {
         sjekkKorreksjonTilgang()
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
-        refusjonService.settMinusBeløpOmFratrukketFerieGirMinusForForrigeRefusjonOmDenFinnes(korreksjon)
+        refusjonService.settMinusBeløpFraTidligereRefusjonerPåAvtalen(korreksjon)
         sjekkLesetilgang(korreksjon)
         val refusjon = finnRefusjon(korreksjon.korrigererRefusjonId)
         sjekkLesetilgang(refusjon)
@@ -177,7 +175,7 @@ data class InnloggetSaksbehandler(
     fun endreBruttolønn(id: String, inntekterKunFraTiltaket: Boolean?, endretBruttoLønn: Int?) {
         sjekkKorreksjonTilgang()
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
-        refusjonService.settMinusBeløpOmFratrukketFerieGirMinusForForrigeRefusjonOmDenFinnes(korreksjon)
+        refusjonService.settMinusBeløpFraTidligereRefusjonerPåAvtalen(korreksjon)
         sjekkLesetilgang(korreksjon)
         korreksjon.endreBruttolønn(inntekterKunFraTiltaket, endretBruttoLønn)
         korreksjonRepository.save(korreksjon)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/dokgen/RefusjonTilPDFMapper.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/dokgen/RefusjonTilPDFMapper.kt
@@ -59,6 +59,7 @@ object RefusjonTilPDFMapper {
             refusjon.tilskuddsgrunnlag.tilskuddsbeløp,
             refusjon.refusjonsgrunnlag.forrigeRefusjonMinusBeløp,
             refusjon.tilskuddsgrunnlag.avtaleNr.toString() + "-" + (refusjon.tilskuddsgrunnlag.løpenummer -1),
+            refusjon.refusjonsgrunnlag.beregning!!.sumUtgifterFratrukketRefundertBeløp
         )
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/featuretoggles/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/featuretoggles/FeatureToggleService.kt
@@ -29,7 +29,8 @@ class FeatureToggleService @Autowired constructor(
     }
 
     fun isEnabled(feature: String?, innloggetSaksbehandler: InnloggetSaksbehandler): Boolean {
-        return unleash.isEnabled(feature!!, contextMedInnloggetBruker(innloggetSaksbehandler.identifikator))
+        return true
+        //return unleash.isEnabled(feature!!, contextMedInnloggetBruker(innloggetSaksbehandler.identifikator))
     }
 
     fun isEnabled(feature: String?, identifikator: String): Boolean {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/FakeInntektskomponentService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/FakeInntektskomponentService.kt
@@ -25,7 +25,6 @@ class FakeInntektskomponentService : InntektskomponentService {
             // Simulerer minus beløp for (Jon Janson Minus Beløp) i test data
             val inntektslinjer = ArrayList<Inntektslinje>()
             val måned = YearMonth.of(datoFra.year, datoFra.month)
-            println(måned)
             inntektslinjer.add(Inntektslinje("LOENNSINNTEKT", "fastloenn", 20000.0,  måned, datoTil, måned.atEndOfMonth()))
             // Kan ikke ha minus på alle. Må kunne teste positivt. Så kun minus på en inntekt to måneder bak
             println(Period.between(datoFra, Now.localDate().with(TemporalAdjusters.firstDayOfMonth())).months == 3)
@@ -37,7 +36,6 @@ class FakeInntektskomponentService : InntektskomponentService {
             // Simulerer minus beløp for (Jon Janson Minus Beløp) i test data
             val inntektslinjer = ArrayList<Inntektslinje>()
             val måned = YearMonth.of(datoFra.year, datoFra.month)
-            println(måned)
             inntektslinjer.add(Inntektslinje("LOENNSINNTEKT", "fastloenn", 20000.0,  måned, datoTil, måned.atEndOfMonth()))
             if (Math.random() > 0.5) {
                 inntektslinjer.add(Inntektslinje("LOENNSINNTEKT", "trekkILoennForFerie", -25000.0,  måned, datoTil, måned.atEndOfMonth()))

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/FakeInntektskomponentService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/FakeInntektskomponentService.kt
@@ -1,11 +1,13 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.inntekt
 
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Inntektslinje
+import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.Period
 import java.time.YearMonth
+import java.time.temporal.TemporalAdjusters
 import kotlin.streams.toList
 
 @Service
@@ -23,9 +25,24 @@ class FakeInntektskomponentService : InntektskomponentService {
             // Simulerer minus beløp for (Jon Janson Minus Beløp) i test data
             val inntektslinjer = ArrayList<Inntektslinje>()
             val måned = YearMonth.of(datoFra.year, datoFra.month)
+            println(måned)
             inntektslinjer.add(Inntektslinje("LOENNSINNTEKT", "fastloenn", 20000.0,  måned, datoTil, måned.atEndOfMonth()))
-            inntektslinjer.add(Inntektslinje("LOENNSINNTEKT", "trekkILoennForFerie", -25000.0,  måned, datoTil, måned.atEndOfMonth()))
-            return Pair(inntektslinjer, "fake respons")
+            // Kan ikke ha minus på alle. Må kunne teste positivt. Så kun minus på en inntekt to måneder bak
+            println(Period.between(datoFra, Now.localDate().with(TemporalAdjusters.firstDayOfMonth())).months == 3)
+            if(Period.between(datoFra, Now.localDate().with(TemporalAdjusters.firstDayOfMonth())).months == 3) {
+                inntektslinjer.add(Inntektslinje("LOENNSINNTEKT", "trekkILoennForFerie", -25000.0,  måned, datoTil, måned.atEndOfMonth()))
+            }
+            return Pair(inntektslinjer, "fake respons med minus")
+        } else if (fnr == "08124521514") {
+            // Simulerer minus beløp for (Jon Janson Minus Beløp) i test data
+            val inntektslinjer = ArrayList<Inntektslinje>()
+            val måned = YearMonth.of(datoFra.year, datoFra.month)
+            println(måned)
+            inntektslinjer.add(Inntektslinje("LOENNSINNTEKT", "fastloenn", 20000.0,  måned, datoTil, måned.atEndOfMonth()))
+            if (Math.random() > 0.5) {
+                inntektslinjer.add(Inntektslinje("LOENNSINNTEKT", "trekkILoennForFerie", -25000.0,  måned, datoTil, måned.atEndOfMonth()))
+            }
+            return Pair(inntektslinjer, "fake respons med minus")
         }
 
         val inntektslinjer = ArrayList<Inntektslinje>()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/FakeInntektskomponentService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/FakeInntektskomponentService.kt
@@ -40,7 +40,7 @@ class FakeInntektskomponentService : InntektskomponentService {
             if (Math.random() > 0.5) {
                 inntektslinjer.add(Inntektslinje("LOENNSINNTEKT", "trekkILoennForFerie", -25000.0,  måned, datoTil, måned.atEndOfMonth()))
             }
-            return Pair(inntektslinjer, "fake respons med minus")
+            return Pair(inntektslinjer, "fake respons med mulig minus")
         }
 
         val inntektslinjer = ArrayList<Inntektslinje>()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/pdf/RefusjonTilPDF.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/pdf/RefusjonTilPDF.kt
@@ -33,6 +33,7 @@ data class RefusjonTilPDF(
     val tidligereRefundertBeløp: Int,
     val tilskuddsbeløp: Int,
     val forrigeRefusjonMinusBeløp: Int,
-    val forrigeRefusjonsnummer: String
+    val forrigeRefusjonsnummer: String,
+    val sumUtgifterFratrukketRefundertBeløp: Int
 )
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverRefusjonController.kt
@@ -6,6 +6,7 @@ import no.nav.arbeidsgiver.tiltakrefusjon.dokgen.DokgenService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.data.domain.Page
 import org.springframework.http.*
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.*
 
 
@@ -96,6 +97,12 @@ class ArbeidsgiverRefusjonController(
         arbeidsgiver.settFratrekkRefunderbarBeløp(id, request.fratrekkRefunderbarBeløp, request.refunderbarBeløp)
     }
 
+    @PostMapping("/{id}/utsett-frist")
+    fun utsettFrist(@PathVariable id: String) {
+        val arbeidsgiver = innloggetBrukerService.hentInnloggetArbeidsgiver()
+        arbeidsgiver.utsettFriskSykepenger(id);
+    }
+
     @PostMapping("/{id}/set-inntektslinje-opptjent-i-periode")
     fun endreRefundertInntekslinje(@PathVariable id: String, @RequestBody request: EndreRefundertInntektslinjeRequest) {
         val arbeidsgiver = innloggetBrukerService.hentInnloggetArbeidsgiver()
@@ -107,6 +114,7 @@ class ArbeidsgiverRefusjonController(
     }
 
     @PostMapping("/{id}/godkjenn")
+    @Transactional
     fun godkjenn(@PathVariable id: String) {
         val arbeidsgiver = innloggetBrukerService.hentInnloggetArbeidsgiver()
         arbeidsgiver.godkjenn(id)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/GodkjennEldreRefusjonFørstException.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/GodkjennEldreRefusjonFørstException.kt
@@ -1,7 +1,0 @@
-package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
-
-import no.nav.arbeidsgiver.tiltakrefusjon.Feilkode
-import no.nav.arbeidsgiver.tiltakrefusjon.FeilkodeException
-
-class GodkjennEldreRefusjonFørstException : FeilkodeException(Feilkode.GODKJENN_TIDLIGERE_REFUSJON_FØRST) {
-}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Minusbelop.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Minusbelop.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 import com.github.guepardoapps.kulid.ULID
+import org.apache.kafka.common.protocol.types.Field.Bool
 import javax.persistence.Entity
 import javax.persistence.Id
 
@@ -8,7 +9,8 @@ import javax.persistence.Id
 class Minusbelop(
     val avtaleNr: Int,
     var beløp: Int? = null,
-    var løpenummer: Int? = null
+    var løpenummer: Int? = null,
+    var gjortOpp: Boolean = false
 ) {
     @Id
     val id: String = ULID.random()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Minusbelop.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Minusbelop.kt
@@ -1,0 +1,15 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
+
+import com.github.guepardoapps.kulid.ULID
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Entity
+class Minusbelop(
+    val avtaleNr: Int,
+    var beløp: Int? = null,
+    var løpenummer: Int? = null
+) {
+    @Id
+    val id: String = ULID.random()
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/MinusbelopRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/MinusbelopRepository.kt
@@ -1,0 +1,7 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MinusbelopRepository : JpaRepository<Minusbelop, String> {
+    fun findAllByAvtaleNr(avtaleNr: Int): List<Minusbelop>
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -251,6 +251,10 @@ class Refusjon(
     }
 
     fun forlengFrist(nyFrist: LocalDate, årsak: String, utførtAv: String) {
+        forlengFrist(nyFrist, årsak, utførtAv, false)
+    }
+
+    fun forlengFrist(nyFrist: LocalDate, årsak: String, utførtAv: String, enforce: Boolean) {
         oppdaterStatus()
         krevStatus(RefusjonStatus.FOR_TIDLIG, RefusjonStatus.KLAR_FOR_INNSENDING)
 
@@ -262,7 +266,7 @@ class Refusjon(
         // Opprinnelig frist er er 2 mnd. Det er enten 2 mnd etter tilskuddTom eller 2 mnd etter godkjentAvBeslutterTidspunkt.
         // Maks forlengelse er 1 mnd.
         val opprinneligFrist = lagFristForGodkjenning()
-        if (nyFrist > antallMånederEtter(opprinneligFrist, 1)) {
+        if (!enforce && (nyFrist > antallMånederEtter(opprinneligFrist, 1))) {
             throw FeilkodeException(Feilkode.FOR_LANG_FORLENGELSE_AV_FRIST)
         }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -171,11 +171,6 @@ class Refusjon(
             status = RefusjonStatus.GODKJENT_NULLBELØP
             registerEvent(RefusjonGodkjentNullBeløp(this, utførtAv))
         } else if(!refusjonsgrunnlag.refusjonsgrunnlagetErPositivt()) {
-            // Lagre et minusbeløp
-            minusbelop = Minusbelop(
-                avtaleNr = refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr,
-                beløp = refusjonsgrunnlag.beregning?.refusjonsbeløp,
-                løpenummer = refusjonsgrunnlag.tilskuddsgrunnlag.løpenummer)
             status = RefusjonStatus.GODKJENT_MINUSBELØP
             registerEvent(RefusjonGodkjentMinusBeløp(this, utførtAv))
         } else {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonGodkjentLytter.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonGodkjentLytter.kt
@@ -20,7 +20,7 @@ class RefusjonGodkjentLytter(
         val alleMinusBeløpPåAvtalen = minusbelopRepository.findAllByAvtaleNr(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr);
         // Er det minusbeløp på avtalen kan de nå nullstilles da refusjonen er godkjent uten minusbeløp
         alleMinusBeløpPåAvtalen.forEach{
-            it.beløp = 0
+            it.gjortOpp = true
             minusbelopRepository.save(it)
         }
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonGodkjentLytter.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonGodkjentLytter.kt
@@ -5,7 +5,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
 @Component
@@ -13,8 +12,6 @@ class RefusjonGodkjentLytter(
     val refusjonRepository: RefusjonRepository,
     val minusbelopRepository: MinusbelopRepository
 ) {
-
-
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun refusjonGodkjent(event: GodkjentAvArbeidsgiver) {
@@ -22,12 +19,9 @@ class RefusjonGodkjentLytter(
         val refusjon = refusjonRepository.findByIdOrNull(event.refusjon.id) ?: throw RuntimeException("Finner ikke refusjon med id=${event.refusjon.id}")
         val alleMinusBeløpPåAvtalen = minusbelopRepository.findAllByAvtaleNr(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr);
         // Er det minusbeløp på avtalen kan de nå nullstilles da refusjonen er godkjent uten minusbeløp
-        println("Skal vi nullstille?")
         alleMinusBeløpPåAvtalen.forEach{
             it.beløp = 0
-            //minusbelopRepository.delete(it)
             minusbelopRepository.save(it)
-            println("ja..")
         }
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonGodkjentLytter.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonGodkjentLytter.kt
@@ -1,0 +1,33 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
+
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.GodkjentAvArbeidsgiver
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class RefusjonGodkjentLytter(
+    val refusjonRepository: RefusjonRepository,
+    val minusbelopRepository: MinusbelopRepository
+) {
+
+
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun refusjonGodkjent(event: GodkjentAvArbeidsgiver) {
+        // Her kan man nullstille eventuelle minusbeløp
+        val refusjon = refusjonRepository.findByIdOrNull(event.refusjon.id) ?: throw RuntimeException("Finner ikke refusjon med id=${event.refusjon.id}")
+        val alleMinusBeløpPåAvtalen = minusbelopRepository.findAllByAvtaleNr(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr);
+        // Er det minusbeløp på avtalen kan de nå nullstilles da refusjonen er godkjent uten minusbeløp
+        println("Skal vi nullstille?")
+        alleMinusBeløpPåAvtalen.forEach{
+            it.beløp = 0
+            //minusbelopRepository.delete(it)
+            minusbelopRepository.save(it)
+            println("ja..")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonGodkjentMinusBeløpLytter.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonGodkjentMinusBeløpLytter.kt
@@ -1,0 +1,39 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
+
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.RefusjonGodkjentMinusBeløp
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class RefusjonGodkjentMinusBeløpLytter(
+    val refusjonRepository: RefusjonRepository,
+    val minusbelopRepository: MinusbelopRepository
+) {
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun refusjonGodkjentMinusbeløp(event: RefusjonGodkjentMinusBeløp) {
+        // Lagre et minusbeløp. Må evt dra fra gamle minusbeløp så det ikke blir dobbelt opp
+        val refusjon = refusjonRepository.findByIdOrNull(event.refusjon.id) ?: throw RuntimeException("Finner ikke refusjon med id=${event.refusjon.id}")
+        val alleMinusBeløpPåAvtalen = minusbelopRepository.findAllByAvtaleNr(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr);
+
+        val sumMinusbelop = alleMinusBeløpPåAvtalen
+            .map { minusbelop -> minusbelop.beløp}
+            .filterNotNull()
+            .reduceOrNull{sum, beløp -> sum + beløp}
+        println("<<<<<<<<<<< total gammel sum ${sumMinusbelop}")
+        val minusbelop = Minusbelop(
+            avtaleNr = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr,
+            beløp = refusjon.refusjonsgrunnlag.beregning?.refusjonsbeløp,
+            løpenummer = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.løpenummer)
+        if(sumMinusbelop != null) {
+            minusbelop.beløp = minusbelop.beløp?.minus(sumMinusbelop)
+        }
+        println("<<<<<<<<<<<< refusjonens minus ${refusjon.refusjonsgrunnlag.beregning?.refusjonsbeløp}")
+        println("<<<<<<<<<<<< totalt ${minusbelop.beløp}")
+        refusjon.minusbelop = minusbelop
+        refusjonRepository.save(refusjon)
+    }
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonGodkjentMinusBeløpLytter.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonGodkjentMinusBeløpLytter.kt
@@ -17,22 +17,19 @@ class RefusjonGodkjentMinusBeløpLytter(
     fun refusjonGodkjentMinusbeløp(event: RefusjonGodkjentMinusBeløp) {
         // Lagre et minusbeløp. Må evt dra fra gamle minusbeløp så det ikke blir dobbelt opp
         val refusjon = refusjonRepository.findByIdOrNull(event.refusjon.id) ?: throw RuntimeException("Finner ikke refusjon med id=${event.refusjon.id}")
-        val alleMinusBeløpPåAvtalen = minusbelopRepository.findAllByAvtaleNr(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr);
 
-        val sumMinusbelop = alleMinusBeløpPåAvtalen
-            .map { minusbelop -> minusbelop.beløp}
-            .filterNotNull()
-            .reduceOrNull{sum, beløp -> sum + beløp}
-        println("<<<<<<<<<<< total gammel sum ${sumMinusbelop}")
-        val minusbelop = Minusbelop(
+        // Nullstill alle gamle beløp. Det er nå gjort opp og vi lagrer nytt minusbeløp på denne refusjonen.
+        val alleMinusBeløp = minusbelopRepository.findAllByAvtaleNr(refusjon.tilskuddsgrunnlag.avtaleNr)
+        alleMinusBeløp.forEach {
+            it.gjortOpp = true
+            minusbelopRepository.save(it)
+        }
+
+        val minusbelop = Minusbelop (
             avtaleNr = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr,
             beløp = refusjon.refusjonsgrunnlag.beregning?.refusjonsbeløp,
             løpenummer = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.løpenummer)
-        if(sumMinusbelop != null) {
-            minusbelop.beløp = minusbelop.beløp?.minus(sumMinusbelop)
-        }
-        println("<<<<<<<<<<<< refusjonens minus ${refusjon.refusjonsgrunnlag.beregning?.refusjonsbeløp}")
-        println("<<<<<<<<<<<< totalt ${minusbelop.beløp}")
+
         refusjon.minusbelop = minusbelop
         refusjonRepository.save(refusjon)
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -80,6 +80,7 @@ class RefusjonService(
         val alleMinusbeløp = minusbelopRepository.findAllByAvtaleNr(avtaleNr = avtaleNr)
         if(!alleMinusbeløp.isNullOrEmpty()) {
             val sumMinusbelop = alleMinusbeløp
+                .filter { !it.gjortOpp }
                 .map { minusbelop -> minusbelop.beløp}
                 .filterNotNull()
                 .reduceOrNull{sum, beløp -> sum + beløp}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -9,13 +9,16 @@ import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeForko
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeGodkjentMelding
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional
 class RefusjonService(
     val inntektskomponentService: InntektskomponentService,
     val refusjonRepository: RefusjonRepository,
     val korreksjonRepository: KorreksjonRepository,
     val kontoregisterService: KontoregisterService,
+    val minusbelopRepository: MinusbelopRepository
 ) {
     val log = LoggerFactory.getLogger(javaClass)
 
@@ -71,28 +74,22 @@ class RefusjonService(
      * men at vi overfører minusbeløp til neste måned dersom tiltaket fortsetter måneden etter. Hvis tiltaket avsluttes den samme måneden hvor det går i minus,
      * så går refusjonen bare i 0,-.
      */
-    fun settMinusBeløpOmFratrukketFerieGirMinusForForrigeRefusjonOmDenFinnes(denneRefusjon: Refusjon) {
-        val tidligereRefusjonMedMinusBeløpEtterFratrukketFerie: Refusjon =
-            refusjonRepository.finnRefusjonSomSkalSendesMedMinusBeløpEtterFratrukketFerieFørDenne(
-                denneRefusjon.bedriftNr,
-                denneRefusjon.tilskuddsgrunnlag.avtaleNr,
-                denneRefusjon.tilskuddsgrunnlag.tiltakstype,
-                RefusjonStatus.GODKJENT_MINUSBELØP,
-                denneRefusjon.tilskuddsgrunnlag.løpenummer
-            ) ?: return
+    fun settMinusBeløpFraTidligereRefusjonerPåAvtalen(denneRefusjon: Refusjon) {
 
-        if (tidligereRefusjonMedMinusBeløpEtterFratrukketFerie.beregning!!.lønnFratrukketFerie <= 0)
-            denneRefusjon.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(tidligereRefusjonMedMinusBeløpEtterFratrukketFerie.beregning!!.refusjonsbeløp)
+        val avtaleNr = denneRefusjon.tilskuddsgrunnlag.avtaleNr
+        val alleMinusbeløp = minusbelopRepository.findAllByAvtaleNr(avtaleNr = avtaleNr)
+        if(!alleMinusbeløp.isNullOrEmpty()) {
+            val sumMinusbelop = alleMinusbeløp
+                .map { minusbelop -> minusbelop.beløp}
+                .filterNotNull()
+                .reduceOrNull{sum, beløp -> sum + beløp}
+            if (sumMinusbelop != null) {
+                denneRefusjon.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(sumMinusbelop)
+            }
+        }
     }
 
-    fun settOmForrigeRefusjonMåSendesFørst(refusjon: Refusjon){
-        if(refusjon.status != RefusjonStatus.KLAR_FOR_INNSENDING) return
-        val forrigeRefusjonSomMåSendesInnFørst: Refusjon = refusjonRepository.finnRefusjonSomSkalSendesFørDenne(refusjon.bedriftNr,refusjon.tilskuddsgrunnlag.avtaleNr,refusjon.tilskuddsgrunnlag.tiltakstype, RefusjonStatus.KLAR_FOR_INNSENDING, refusjon.tilskuddsgrunnlag.løpenummer).firstOrNull()
-                ?: return
-        if(forrigeRefusjonSomMåSendesInnFørst != refusjon) refusjon.angiRefusjonSomMåSendesFørst(forrigeRefusjonSomMåSendesInnFørst)
-    }
-
-    fun settMinusBeløpOmFratrukketFerieGirMinusForForrigeRefusjonOmDenFinnes(denneKorreksjon: Korreksjon) {
+    fun settMinusBeløpFraTidligereRefusjonerPåAvtalen(denneKorreksjon: Korreksjon) {
         val tidligereRefusjonMedMinusBeløpEtterFratrukketFerie: Refusjon =
             refusjonRepository.finnRefusjonSomSkalSendesMedMinusBeløpEtterFratrukketFerieFørDenne(
                 denneKorreksjon.bedriftNr,
@@ -128,6 +125,7 @@ class RefusjonService(
                 inntekter = inntektsoppslag.first,
                 respons = inntektsoppslag.second
             )
+            println(inntektsgrunnlag)
             refusjon.oppgiInntektsgrunnlag(inntektsgrunnlag, refusjon.inntektsgrunnlag)
             refusjonRepository.save(refusjon)
         } catch (e: Exception) {
@@ -136,17 +134,8 @@ class RefusjonService(
     }
 
     fun godkjennForArbeidsgiver(refusjon: Refusjon, utførtAv: String) {
-        if(måGodkjenneTidligereRefusjonerFørst(refusjon)){
-            throw GodkjennEldreRefusjonFørstException()
-        }
         refusjon.godkjennForArbeidsgiver(utførtAv)
         refusjonRepository.save(refusjon)
-    }
-
-    private fun måGodkjenneTidligereRefusjonerFørst(refusjon:Refusjon): Boolean{
-        if(refusjon.status != RefusjonStatus.KLAR_FOR_INNSENDING) return false
-        val forrigeRefusjonSomMåSendesInnFørst: Refusjon? = refusjonRepository.finnRefusjonSomSkalSendesFørDenne(refusjon.bedriftNr,refusjon.tilskuddsgrunnlag.avtaleNr,refusjon.tilskuddsgrunnlag.tiltakstype, RefusjonStatus.KLAR_FOR_INNSENDING, refusjon.tilskuddsgrunnlag.løpenummer).firstOrNull()
-        return  forrigeRefusjonSomMåSendesInnFørst != null && forrigeRefusjonSomMåSendesInnFørst != refusjon
     }
 
     fun annullerRefusjon(melding: TilskuddsperiodeAnnullertMelding) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -87,6 +87,9 @@ class RefusjonService(
             if (sumMinusbelop != null) {
                 refusjon.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(sumMinusbelop)
                 refusjonRepository.save(refusjon)
+            } else {
+                refusjon.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(0)
+                refusjonRepository.save(refusjon)
             }
         }
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -74,9 +74,9 @@ class RefusjonService(
      * men at vi overfører minusbeløp til neste måned dersom tiltaket fortsetter måneden etter. Hvis tiltaket avsluttes den samme måneden hvor det går i minus,
      * så går refusjonen bare i 0,-.
      */
-    fun settMinusBeløpFraTidligereRefusjonerPåAvtalen(denneRefusjon: Refusjon) {
+    fun settMinusBeløpFraTidligereRefusjonerPåAvtalen(refusjon: Refusjon) {
 
-        val avtaleNr = denneRefusjon.tilskuddsgrunnlag.avtaleNr
+        val avtaleNr = refusjon.tilskuddsgrunnlag.avtaleNr
         val alleMinusbeløp = minusbelopRepository.findAllByAvtaleNr(avtaleNr = avtaleNr)
         if(!alleMinusbeløp.isNullOrEmpty()) {
             val sumMinusbelop = alleMinusbeløp
@@ -85,7 +85,8 @@ class RefusjonService(
                 .filterNotNull()
                 .reduceOrNull{sum, beløp -> sum + beløp}
             if (sumMinusbelop != null) {
-                denneRefusjon.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(sumMinusbelop)
+                refusjon.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(sumMinusbelop)
+                refusjonRepository.save(refusjon)
             }
         }
     }

--- a/src/main/resources/db/migration/V35__flytter_minus_belop_egen_tabell.sql
+++ b/src/main/resources/db/migration/V35__flytter_minus_belop_egen_tabell.sql
@@ -3,7 +3,8 @@ create table minusbelop
     id                     varchar primary key,
     avtale_nr              integer,
     beløp                  numeric,
-    løpenummer             integer
+    løpenummer             integer,
+    gjort_opp              boolean
 );
 
 alter table refusjon add column minusbelop_id varchar references minusbelop (id);

--- a/src/main/resources/db/migration/V35__flytter_minus_belop_egen_tabell.sql
+++ b/src/main/resources/db/migration/V35__flytter_minus_belop_egen_tabell.sql
@@ -1,0 +1,11 @@
+create table minusbelop
+(
+    id                     varchar primary key,
+    avtale_nr              integer,
+    beløp                  numeric,
+    løpenummer             integer
+);
+
+alter table refusjon add column minusbelop_id varchar references minusbelop (id);
+
+create index on minusbelop(avtale_nr);

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/IntegrasjonerMockServer.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/IntegrasjonerMockServer.kt
@@ -16,7 +16,7 @@ class IntegrasjonerMockServer(@Value("\${wiremock.port}") val wiremockPort: Int)
     private val server: WireMockServer = WireMockServer(WireMockConfiguration
         .options()
         .usingFilesUnderClasspath(".")
-        //.notifier(ConsoleNotifier(true))
+        .notifier(ConsoleNotifier(true))
         .port(wiremockPort))
 
     init {

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/IntegrasjonerMockServer.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/IntegrasjonerMockServer.kt
@@ -16,7 +16,7 @@ class IntegrasjonerMockServer(@Value("\${wiremock.port}") val wiremockPort: Int)
     private val server: WireMockServer = WireMockServer(WireMockConfiguration
         .options()
         .usingFilesUnderClasspath(".")
-        .notifier(ConsoleNotifier(true))
+        //.notifier(ConsoleNotifier(true))
         .port(wiremockPort))
 
     init {

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
@@ -66,7 +66,7 @@ fun refusjoner(): List<Refusjon> {
     }
 
     fun `Jon Janson Ferietrekk minus beløp 1`(): Refusjon {
-        val deltakerFnr = "08098613316"
+        val deltakerFnr = "08124521514"
         val bedriftNr = "910712306"
         return Refusjon(
             tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(
@@ -87,7 +87,7 @@ fun refusjoner(): List<Refusjon> {
     }
 
     fun `Jon Janson Ferietrekk minus beløp 2`(): Refusjon {
-        val deltakerFnr = "01092111111"
+        val deltakerFnr = "08124521514"
         val bedriftNr = "910712306"
         return Refusjon(
             tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(
@@ -108,7 +108,7 @@ fun refusjoner(): List<Refusjon> {
     }
 
     fun `Jon Janson Ferietrekk minus beløp 3`(): Refusjon {
-        val deltakerFnr = "01092111111"
+        val deltakerFnr = "08124521514"
         val bedriftNr = "910712306"
         return Refusjon(
             tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(
@@ -128,10 +128,32 @@ fun refusjoner(): List<Refusjon> {
         )
     }
 
+    fun `Jon Janson Ferietrekk minus beløp 4`(): Refusjon {
+        val deltakerFnr = "08124521514"
+        val bedriftNr = "910712306"
+        return Refusjon(
+            tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(
+                løpenummer = 4,
+                lønnstilskuddsprosent = 60,
+                otpSats = 0.03,
+                feriepengerSats = 0.125,
+                arbeidsgiveravgiftSats = 0.141,
+                avtaleNr = 7,
+                deltakerFnr = deltakerFnr,
+                tilskuddsbeløp = 30000,
+                bedriftNr = bedriftNr,
+                deltakerFornavn = "Jon",
+                deltakerEtternavn = "Janson Ferietrekk minus beløp 4",
+                veilederNavIdent = "Z123456"
+            ), bedriftNr = bedriftNr, deltakerFnr = deltakerFnr
+        )
+    }
+
     return listOf(
         `Jon Janson Ferietrekk minus beløp 1`(),
         `Jon Janson Ferietrekk minus beløp 2`(),
         `Jon Janson Ferietrekk minus beløp 3`(),
+        `Jon Janson Ferietrekk minus beløp 4`(),
         kiellandNy,
         kiellandGammel,
         BjørnsonUtgått,

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonApiTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonApiTest.kt
@@ -95,7 +95,7 @@ class RefusjonApiTest(
 
         assertNull(liste.find { it.refusjonsgrunnlag.tilskuddsgrunnlag.enhet != "1000" })
         assertNull(liste.find { it.deltakerFnr == "07098142678" })
-        assertEquals(18, liste.size) // Det er 9 stk i TestData som ikke har det fødselsnummeret som gir 'Deny'
+        assertEquals(19, liste.size) // Det er 19 stk i TestData som ikke har det fødselsnummeret som gir 'Deny'
 
     }
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
@@ -151,7 +151,6 @@ class RefusjonServiceTest(
         refusjonService.gjørInntektsoppslag(refusjon2)
 
         assertThat(refusjonRepository.findAll().count()).isEqualTo(2)
-        assertThrows<GodkjennEldreRefusjonFørstException> { refusjonService.godkjennForArbeidsgiver(refusjon2,"999999999")}
     }
 
     @Test

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
@@ -84,77 +84,7 @@ class RefusjonServiceTest(
     }
 
     @Test
-    fun `rekkefølge GODKJENNING av refusjon, sperre for løpenummer 2 om løpenummer 1 ikke er godkjent først`(){
-
-        val deltakerFnr = "00000000000"
-        val tilskuddMelding = TilskuddsperiodeGodkjentMelding(
-            avtaleId = "1",
-            tilskuddsbeløp = 1000,
-            tiltakstype = Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD,
-            deltakerEtternavn = "Mus",
-            deltakerFornavn = "Mikke",
-            arbeidsgiverFornavn = "Arne",
-            arbeidsgiverEtternavn = "Arbeidsgiver",
-            arbeidsgiverTlf = "41111111",
-            arbeidsgiveravgiftSats = 0.101,
-            avtaleInnholdId = "1",
-            bedriftNavn = "Bedriften AS",
-            bedriftNr = "999999999",
-            deltakerFnr = deltakerFnr,
-            feriepengerSats = 0.141,
-            otpSats = 0.02,
-            tilskuddFom =  Now.localDate().minusWeeks(4),
-            tilskuddTom = Now.localDate().minusDays(1),
-            tilskuddsperiodeId = "1",
-            veilederNavIdent = "X123456",
-            lønnstilskuddsprosent = 60,
-            avtaleNr = 3456,
-            løpenummer = 1,
-            resendingsnummer = null,
-            enhet = "1000",
-            godkjentTidspunkt = LocalDateTime.now()
-        )
-        val tilskuddMelding2LittEldreMedLøpenummer2 = TilskuddsperiodeGodkjentMelding(
-            avtaleId = "1",
-            tilskuddsbeløp = 1000,
-            tiltakstype = Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD,
-            deltakerEtternavn = "Mus",
-            deltakerFornavn = "Mikke",
-            arbeidsgiverFornavn = "Arne",
-            arbeidsgiverEtternavn = "Arbeidsgiver",
-            arbeidsgiverTlf = "41111111",
-            arbeidsgiveravgiftSats = 0.101,
-            avtaleInnholdId = "2",
-            bedriftNavn = "Bedriften AS",
-            bedriftNr = "999999999",
-            deltakerFnr = deltakerFnr,
-            feriepengerSats = 0.141,
-            otpSats = 0.02,
-            tilskuddFom = Now.localDate().minusWeeks(3),
-            tilskuddTom = Now.localDate().minusDays(1),
-            tilskuddsperiodeId = "2",
-            veilederNavIdent = "X123456",
-            lønnstilskuddsprosent = 60,
-            avtaleNr = 3456,
-            løpenummer = 2,
-            resendingsnummer = null,
-            enhet = "1000",
-            godkjentTidspunkt = LocalDateTime.now()
-        )
-
-        val refusjon1 = refusjonService.opprettRefusjon(tilskuddMelding)!!
-        refusjonService.gjørBedriftKontonummeroppslag(refusjon1)
-        refusjonService.gjørInntektsoppslag(refusjon1)
-
-        val refusjon2 = refusjonService.opprettRefusjon(tilskuddMelding2LittEldreMedLøpenummer2)!!
-        refusjonService.gjørBedriftKontonummeroppslag(refusjon2)
-        refusjonService.gjørInntektsoppslag(refusjon2)
-
-        assertThat(refusjonRepository.findAll().count()).isEqualTo(2)
-    }
-
-    @Test
-    fun `rekkefølge GODKJENNING av refusjon, sperre for løpenummer 3 om løpenummer 2 ikke er godkjent først`(){
+    fun `rekkefølge GODKJENNING av refusjon, ingen krav til godkjenning i rekkefølge`(){
 
         val deltakerFnr = "00000000000"
         val tilskuddMelding = TilskuddsperiodeGodkjentMelding(
@@ -256,9 +186,9 @@ class RefusjonServiceTest(
         gjørInntektoppslagForRefusjon(refusjon3)
 
         assertThat(refusjonRepository.findAll().count()).isEqualTo(3)
-        assertDoesNotThrow { refusjonService.godkjennForArbeidsgiver(refusjon1,"999999999")}
-        assertDoesNotThrow { refusjonService.godkjennForArbeidsgiver(refusjon2,"999999999")}
         assertDoesNotThrow { refusjonService.godkjennForArbeidsgiver(refusjon3,"999999999")}
+        assertDoesNotThrow { refusjonService.godkjennForArbeidsgiver(refusjon2,"999999999")}
+        assertDoesNotThrow { refusjonService.godkjennForArbeidsgiver(refusjon1,"999999999")}
     }
 
     @Test

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -18,7 +18,12 @@ spring:
     username: sa
     password: sa
     driver-class-name: org.h2.Driver
-
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        use_sql_comments: true
+        format_sql: true
   h2:
     console:
       enabled: true


### PR DESCRIPTION
Denne PR endrer hvordan sykepenger håndteres. Sykepenger legges inn på samme måte som tidligere, men man får nå mulighet å vente med å godkjenne til man faktisk har beløpet. Fristen utsettes automatisk 6 mnd om man velger JA.

Får å håndtere dette er rekkefølgekravet slettet. Det innebærer at evt minusbeløp grunne feriepenger ikke lenger lagres på en refusjon, men i egen tabelle knyttet til avtalenr. Man kan altså godkjenne refusjoner uten rekkefølgekrav og minusbeløp vil legges til den man godkjenner.
