### PR TITLE
Endepunkt for forlengelse av alle refusjonsfrister før gitt dato

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
@@ -109,6 +109,29 @@ class AdminController(
     }
 
     @Unprotected
+    @PostMapping("forleng-frister-til-og-med-dato")
+    fun forlengFristerTilOgMedDato(@RequestBody request: ForlengFristerTilOgMedRequest) {
+        logger.info("Bruker AdminController for å forlenge refusjoner med frist før ${request.tilDato} til ny frist: ${request.nyFrist}")
+        val refusjoner = refusjonRepository.findAllByFristForGodkjenningBefore(request.tilDato)
+        logger.info("Fant ${refusjoner.size} refusjoner som skal forlenges")
+        var fristerForlenget = 0
+        for (refusjon in refusjoner) {
+            try {
+                refusjon.forlengFrist(request.nyFrist, request.årsak, "admin", request.enforce)
+                refusjonRepository.save(refusjon)
+                fristerForlenget++
+            } catch (e: FeilkodeException) {
+                if (e.feilkode == Feilkode.FOR_LANG_FORLENGELSE_AV_FRIST) {
+                    logger.warn("Forlengelse av frist på refusjon med id=${refusjon.id} overskrider grensen på 1 måned")
+                } else {
+                    throw e
+                }
+            }
+        }
+        logger.info("Forlengte frister på $fristerForlenget refusjoner")
+    }
+
+    @Unprotected
     @PostMapping("annuller-tilskuddsperioder-manuelt")
     fun annullerTilskuddsperioderIRefusjonManuelt(@RequestBody request: AnnullerTilskuddsperioderRequest) {
         logger.info("Bruker AdminController for å annullere tilskuddsperioder i {} refusjoner", request.refusjonIder.size)
@@ -136,6 +159,7 @@ class AdminController(
 data class KorreksjonRequest(val refusjonIder: List<String>, val korreksjonsgrunner: Set<Korreksjonsgrunn>)
 
 data class ForlengFristerRequest(val refusjonIder: List<String>, val nyFrist: LocalDate, val årsak: String, val enforce: Boolean)
+data class ForlengFristerTilOgMedRequest(val tilDato: LocalDate, val nyFrist: LocalDate, val årsak: String, val enforce: Boolean)
 
 data class AnnullerTilskuddsperioderRequest(val refusjonIder: List<String>, val utførtAv: String, val årsak: String)
 data class AnnullerTilskuddsperioderIUtgåtteRefusjonerRequest(val utførtAv: String, val årsak: String)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonRepository.kt
@@ -2,11 +2,13 @@
 
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
+
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.LocalDate
 
 
 interface RefusjonRepository : JpaRepository<Refusjon, String> {
@@ -18,6 +20,7 @@ interface RefusjonRepository : JpaRepository<Refusjon, String> {
     fun findAllByRefusjonsgrunnlag_Tilskuddsgrunnlag_TilskuddsperiodeId(tilskuddsperiodeId: String): List<Refusjon>
     fun findAllByStatus(status: RefusjonStatus): List<Refusjon>
     fun findAllByRefusjonsgrunnlag_Tilskuddsgrunnlag_AvtaleNr(avtaleNr: Int): List<Refusjon>
+    fun findAllByFristForGodkjenningBefore(fristForGodkjenning: LocalDate): List<Refusjon>
 
     @Query("select r from Refusjon r where r.bedriftNr in (:bedriftNr) and (:status is null or r.status = :status) " +
             "and (:tiltakstype is null or r.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype = :tiltakstype) " +

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonRepository.kt
@@ -2,7 +2,6 @@
 
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
-
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository


### PR DESCRIPTION
Nytt admin-endepunkt for forlengelse av frist på refusjoner som har frist før oppgitt dato. Nyttig når man f.eks. ønsker å forlenge et stort antall refusjoner som snart har frist for godkjenning.