### PR TITLE
Sjekker at man faktisk er i feripengemåneden før det beløpet trekkes

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Inntektslinje.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Inntektslinje.kt
@@ -36,8 +36,11 @@ data class Inntektslinje(
         inntektType == "LOENNSINNTEKT" && inkluderteLønnsbeskrivelser.contains(beskrivelse)
 
     @JsonProperty
-    fun skalTrekkesIfraInntektsgrunnlag() =
-        inntektType == "LOENNSINNTEKT" && inkluderteFratrekkbeskrivelser.contains(beskrivelse)
+    fun skalTrekkesIfraInntektsgrunnlag(tilskuddFom: LocalDate): Boolean {
+        val skalTrekkes = inntektType == "LOENNSINNTEKT" && inkluderteFratrekkbeskrivelser.contains(beskrivelse) && måned == YearMonth.from(tilskuddFom)
+        return skalTrekkes
+    }
+
 }
 
 val inkluderteFratrekkbeskrivelser = listOf<String>("trekkILoennForFerie")

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
@@ -43,11 +43,12 @@ fun beregnRefusjonsbeløp(
     tidligereUtbetalt: Int,
     korrigertBruttoLønn: Int? = null,
     fratrekkRefunderbarSum: Int? = null,
-    forrigeRefusjonMinusBeløp: Int = 0
+    forrigeRefusjonMinusBeløp: Int = 0,
+    tilskuddFom: LocalDate
 ): Beregning {
     val kalkulertBruttoLønn = kalkulerBruttoLønn(inntekter).roundToInt()
     val lønn = if (korrigertBruttoLønn != null) minOf(korrigertBruttoLønn, kalkulertBruttoLønn) else kalkulertBruttoLønn
-    val trekkgrunnlagFerie = leggSammenTrekkGrunnlag(inntekter).roundToInt()
+    val trekkgrunnlagFerie = leggSammenTrekkGrunnlag(inntekter, tilskuddFom).roundToInt()
     val fratrekkRefunderbarBeløp = fratrekkRefunderbarSum ?: 0
     val lønnFratrukketFerie = lønn - trekkgrunnlagFerie
     val feriepenger = lønnFratrukketFerie * tilskuddsgrunnlag.feriepengerSats
@@ -86,9 +87,10 @@ fun beregnRefusjonsbeløp(
 }
 
 fun leggSammenTrekkGrunnlag(
-    inntekter: List<Inntektslinje>
+    inntekter: List<Inntektslinje>,
+    tilskuddFom: LocalDate
 ): Double =
-    inntekter.filter { it.skalTrekkesIfraInntektsgrunnlag() }
+    inntekter.filter { it.skalTrekkesIfraInntektsgrunnlag(tilskuddFom) }
         .sumOf { inntekt -> if (inntekt.beløp < 0) (inntekt.beløp * -1) else inntekt.beløp }
 
 fun kalkulerBruttoLønn(

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsgrunnlag.kt
@@ -6,7 +6,6 @@ import no.nav.arbeidsgiver.tiltakrefusjon.FeilkodeException
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
-import java.time.YearMonth
 import javax.persistence.*
 
 @Entity
@@ -116,7 +115,8 @@ class Refusjonsgrunnlag(
                 tidligereUtbetalt = tidligereUtbetalt,
                 korrigertBruttoLønn = endretBruttoLønn,
                 fratrekkRefunderbarSum = refunderbarBeløp,
-            forrigeRefusjonMinusBeløp = forrigeRefusjonMinusBeløp)
+                forrigeRefusjonMinusBeløp = forrigeRefusjonMinusBeløp,
+                tilskuddFom = tilskuddsgrunnlag.tilskuddFom)
             return true
         }
         return false

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonberegnerFratrekkFerieTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonberegnerFratrekkFerieTest.kt
@@ -88,12 +88,30 @@ class RefusjonberegnerFratrekkFerieTest(
     }
 
     @Test
-    fun `hent inntektsoppslag som har feriefratrekk og beregn`() {
-        val TREKKFORFERIEGRUNNLAG: Int = 7500 // trekk grunnlag fra inntektoppslag
+    fun `hent inntektsoppslag som har feriefratrekk i måned som ikke er refusjonsmåned og beregn`() {
+        val TREKKFORFERIEGRUNNLAG: Int = 0 // trekk grunnlag fra inntektoppslag
 
         val tilskuddsperiodeGodkjentMelding: TilskuddsperiodeGodkjentMelding = lagEnTilskuddsperiodeGodkjentMelding(
             LocalDate.of(2021, 7, 1),
             LocalDate.of(2021, 7, 31),
+            Tiltakstype.SOMMERJOBB,
+            60000,
+            WIREMOCK_IDENT,
+            WIREMOCK_VIRKSOMHET_IDENTIFIKATOR,
+        )
+        val refusjon = opprettRefusjonOgGjørInntektoppslag(tilskuddsperiodeGodkjentMelding)
+
+        assert(refusjon.refusjonsgrunnlag.beregning!!.refusjonsbeløp == `vis utregning med feriefratrekk`(refusjon, TREKKFORFERIEGRUNNLAG))
+        assert(refusjon.refusjonsgrunnlag.beregning!!.fratrekkLønnFerie == TREKKFORFERIEGRUNNLAG)
+    }
+
+    @Test
+    fun `hent inntektsoppslag som har feriefratrekk i måned som er refusjonsmåned og beregn`() {
+        val TREKKFORFERIEGRUNNLAG: Int = 7500 // trekk grunnlag fra inntektoppslag
+
+        val tilskuddsperiodeGodkjentMelding: TilskuddsperiodeGodkjentMelding = lagEnTilskuddsperiodeGodkjentMelding(
+            LocalDate.of(2022, 6, 1),
+            LocalDate.of(2022, 6, 30),
             Tiltakstype.SOMMERJOBB,
             60000,
             WIREMOCK_IDENT,
@@ -128,8 +146,8 @@ class RefusjonberegnerFratrekkFerieTest(
         val TREKKFORFERIEGRUNNLAG: Int = -7500 * -1 // trekk grunnlag fra inntektoppslag
 
         val tilskuddsperiodeGodkjentMelding: TilskuddsperiodeGodkjentMelding = lagEnTilskuddsperiodeGodkjentMelding(
-            LocalDate.of(2021, 9, 1),
-            LocalDate.of(2021, 9, 30),
+            LocalDate.of(2022, 6, 1),
+            LocalDate.of(2022, 6, 30),
             Tiltakstype.SOMMERJOBB,
             60000,
             WIREMOCK_IDENT,

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonberegnerFratrekkFerieTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonberegnerFratrekkFerieTest.kt
@@ -14,6 +14,7 @@ import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.YearMonth
 
 
 @DirtiesContext
@@ -143,7 +144,10 @@ class RefusjonberegnerFratrekkFerieTest(
     @Test
     fun `sjekk at leggSammenTrekkGrunnlag returnerer primiviteInt-eller-double`() {
         val etInntektsgrunnlag = etInntektsgrunnlag()
-        val leggSammenTrekkGrunnlag: Double = leggSammenTrekkGrunnlag(etInntektsgrunnlag.inntekter.toList())
+        val leggSammenTrekkGrunnlag: Double = leggSammenTrekkGrunnlag(
+            etInntektsgrunnlag.inntekter.toList(),
+            tilskuddFom = LocalDate.of(2021,6,1)
+        )
 
         assertThat(leggSammenTrekkGrunnlag).isNotNull
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonsberegnerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonsberegnerTest.kt
@@ -1,10 +1,10 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.inntekt
 
 import com.github.guepardoapps.kulid.ULID
+import no.nav.arbeidsgiver.tiltakrefusjon.etInntektsgrunnlag
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -115,7 +115,8 @@ class RefusjonsberegnerTest {
             tilskuddsgrunnlagSommerJobb,
             0,
             null,
-            null
+            null,
+             tilskuddFom = LocalDate.of(2021,6,1)
         )
         val beregnetBeløpHeleInntektsgrunnlaget = 20856
         assertThat(beregning.refusjonsbeløp).isEqualTo(beregnetBeløpHeleInntektsgrunnlaget)
@@ -133,7 +134,8 @@ class RefusjonsberegnerTest {
             inntektsgrunnlagUregelmessig.inntekter.toList(),
             tilskuddsgrunnlagLønnstilskudd,
             0,
-            null
+            null,
+            tilskuddFom = LocalDate.of(2021,6,1)
         )
         val beregnetBeløpAvAntallDagerJobbetInnenforInntektsgrunnlaget = 20856
         assertThat(beregning.refusjonsbeløp).isEqualTo(beregnetBeløpAvAntallDagerJobbetInnenforInntektsgrunnlaget)

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonsberegningSteps.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonsberegningSteps.kt
@@ -102,7 +102,8 @@ class RefusjonsberegningSteps {
             inntekter = inntekstlinjer,
             tilskuddsgrunnlag = tilskuddsgrunnlag,
             tidligereUtbetalt,
-            korrigertBruttoLønn
+            korrigertBruttoLønn,
+            tilskuddFom = tilskuddsgrunnlag.tilskuddFom
         )
         assertThat(beregnet.refusjonsbeløp).isEqualByComparingTo(refusjon);
     }

--- a/src/test/resources/mappings/inntektskomponenten.json
+++ b/src/test/resources/mappings/inntektskomponenten.json
@@ -567,6 +567,113 @@
                 "identifikator": "08098613316",
                 "aktoerType": "NATURLIG_IDENT"
               },
+              "maanedFom": "2022-06",
+              "maanedTom": "2022-07",
+              "ainntektsfilter": "KontrollArbeidsmarkedstiltakA-inntekt"
+            }
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "arbeidsInntektMaaned": [
+            {
+              "aarMaaned": "2022-06",
+              "arbeidsInntektInformasjon": {
+                "inntektListe": [
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 60000,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2023-06",
+                    "opptjeningsland": "NO",
+                    "opptjeningsperiodeFom": "2022-06-01",
+                    "opptjeningsperiodeTom": "2022-06-30",
+                    "utbetaltIMaaned": "2022-06",
+                    "opplysningspliktig": {
+                      "identifikator": "928497704",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "fastloenn",
+                    "skatteOgAvgiftsregel": "nettoloenn"
+                  },
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": -7500,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-06",
+                    "opptjeningsland": "NO",
+                    "opptjeningsperiodeFom": "2022-06-01",
+                    "opptjeningsperiodeTom": "2022-06-30",
+                    "skattemessigBosattLand": "NO",
+                    "utbetaltIMaaned": "2022-06",
+                    "opplysningspliktig": {
+                      "identifikator": "928497704",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "tilleggsinformasjon": {
+                      "kategori": "NorskKontinentalsokkel"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "trekkILoennForFerie"
+                  }
+                ]
+              }
+            }
+          ],
+          "ident": {
+            "identifikator": "08098613316",
+            "aktoerType": "NATURLIG_IDENT"
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+          "Nav-consumer-Id": "tiltak-refusjon",
+          "Nav-Call-Id": "hoppla1"
+        }
+      }
+    },
+    {
+      "priority": 2,
+      "request": {
+        "method": "POST",
+        "urlPath": "/inntektskomponenten-ws/rs/api/v1/hentinntektliste",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "ident": {
+                "identifikator": "08098613316",
+                "aktoerType": "NATURLIG_IDENT"
+              },
               "maanedFom": "2021-08",
               "maanedTom": "2021-09",
               "ainntektsfilter": "KontrollArbeidsmarkedstiltakA-inntekt"


### PR DESCRIPTION
Hvis man har valgt inntekter før flere måneder, f eks mai og juni, når man behandler mai-refusjonen så ble ferietrekk for juni trukket.

Det er nå fikset sånn at man bare trekker ferie når man faktisk er i refusjonen som har trekket.