### PR TITLE
WIP: Ferietrekk kan være både minus og pluss

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
@@ -50,7 +50,7 @@ fun beregnRefusjonsbeløp(
     val lønn = if (korrigertBruttoLønn != null) minOf(korrigertBruttoLønn, kalkulertBruttoLønn) else kalkulertBruttoLønn
     val trekkgrunnlagFerie = leggSammenTrekkGrunnlag(inntekter, tilskuddFom).roundToInt()
     val fratrekkRefunderbarBeløp = fratrekkRefunderbarSum ?: 0
-    val lønnFratrukketFerie = lønn - trekkgrunnlagFerie
+    val lønnFratrukketFerie = lønn + trekkgrunnlagFerie
     val feriepenger = lønnFratrukketFerie * tilskuddsgrunnlag.feriepengerSats
     val tjenestepensjon = (lønnFratrukketFerie + feriepenger) * tilskuddsgrunnlag.otpSats
     val arbeidsgiveravgift = (lønnFratrukketFerie + tjenestepensjon + feriepenger) * tilskuddsgrunnlag.arbeidsgiveravgiftSats
@@ -86,12 +86,15 @@ fun beregnRefusjonsbeløp(
         sumUtgifterFratrukketRefundertBeløp = sumUtgifterFratrukketRefundertBeløp.roundToInt())
 }
 
-fun leggSammenTrekkGrunnlag(
-    inntekter: List<Inntektslinje>,
-    tilskuddFom: LocalDate
-): Double =
-    inntekter.filter { it.skalTrekkesIfraInntektsgrunnlag(tilskuddFom) }
-        .sumOf { inntekt -> if (inntekt.beløp < 0) (inntekt.beløp * -1) else inntekt.beløp }
+fun leggSammenTrekkGrunnlag(inntekter: List<Inntektslinje>, tilskuddFom: LocalDate): Double {
+    val hehe = inntekter.filter { it.skalTrekkesIfraInntektsgrunnlag(tilskuddFom) }
+        .sumOf { it.beløp }
+    return hehe
+    //return inntekter.filter { it.skalTrekkesIfraInntektsgrunnlag(tilskuddFom) }
+    //    .sumOf { it.beløp }
+}
+
+        //.sumOf { inntekt -> if (inntekt.beløp < 0) (inntekt.beløp * -1) else inntekt.beløp }
 
 fun kalkulerBruttoLønn(
     inntekter: List<Inntektslinje>,

--- a/src/test/resources/mappings/inntektskomponenten.json
+++ b/src/test/resources/mappings/inntektskomponenten.json
@@ -400,7 +400,7 @@
                   },
                   {
                     "inntektType": "LOENNSINNTEKT",
-                    "beloep": 7500,
+                    "beloep": -7500,
                     "fordel": "kontantytelse",
                     "inntektskilde": "A-ordningen",
                     "inntektsperiodetype": "Maaned",
@@ -791,8 +791,370 @@
       "response": {
         "status": 200,
         "jsonBody": {
-          "arbeidsInntektMaaned":[{"aarMaaned":"2022-11","arbeidsInntektInformasjon":{"inntektListe":[{"inntektType":"LOENNSINNTEKT","beloep":1584,"fordel":"kontantytelse","inntektskilde":"A-ordningen","inntektsperiodetype":"Maaned","inntektsstatus":"LoependeInnrapportert","leveringstidspunkt":"2022-08","utbetaltIMaaned":"2022-11","opplysningspliktig":{"identifikator":"936164226","aktoerType":"ORGANISASJON"},"virksomhet":{"identifikator":"873174242","aktoerType":"ORGANISASJON"},"inntektsmottaker":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"},"inngaarIGrunnlagForTrekk":true,"utloeserArbeidsgiveravgift":true,"informasjonsstatus":"InngaarAlltid","beskrivelse":"feriepenger"},{"inntektType":"LOENNSINNTEKT","beloep":1600,"fordel":"kontantytelse","inntektskilde":"A-ordningen","inntektsperiodetype":"Maaned","inntektsstatus":"LoependeInnrapportert","leveringstidspunkt":"2022-08","utbetaltIMaaned":"2022-11","opplysningspliktig":{"identifikator":"936164226","aktoerType":"ORGANISASJON"},"virksomhet":{"identifikator":"873174242","aktoerType":"ORGANISASJON"},"inntektsmottaker":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"},"inngaarIGrunnlagForTrekk":true,"utloeserArbeidsgiveravgift":true,"informasjonsstatus":"InngaarAlltid","beskrivelse":"fastloenn"},{"inntektType":"LOENNSINNTEKT","beloep":-36765.4,"fordel":"kontantytelse","inntektskilde":"A-ordningen","inntektsperiodetype":"Maaned","inntektsstatus":"LoependeInnrapportert","leveringstidspunkt":"2022-08","utbetaltIMaaned":"2022-11","opplysningspliktig":{"identifikator":"978715311","aktoerType":"ORGANISASJON"},"virksomhet":{"identifikator":"972674818","aktoerType":"ORGANISASJON"},"inntektsmottaker":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"},"inngaarIGrunnlagForTrekk":true,"utloeserArbeidsgiveravgift":true,"informasjonsstatus":"InngaarAlltid","beskrivelse":"trekkILoennForFerie"},{"inntektType":"LOENNSINNTEKT","beloep":329,"fordel":"naturalytelse","inntektskilde":"A-ordningen","inntektsperiodetype":"Maaned","inntektsstatus":"LoependeInnrapportert","leveringstidspunkt":"2022-08","utbetaltIMaaned":"2022-11","opplysningspliktig":{"identifikator":"978715311","aktoerType":"ORGANISASJON"},"virksomhet":{"identifikator":"972674818","aktoerType":"ORGANISASJON"},"inntektsmottaker":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"},"inngaarIGrunnlagForTrekk":true,"utloeserArbeidsgiveravgift":true,"informasjonsstatus":"InngaarAlltid","beskrivelse":"annet"},{"inntektType":"LOENNSINNTEKT","beloep":42273.71,"fordel":"kontantytelse","inntektskilde":"A-ordningen","inntektsperiodetype":"Maaned","inntektsstatus":"LoependeInnrapportert","leveringstidspunkt":"2022-08","utbetaltIMaaned":"2022-11","opplysningspliktig":{"identifikator":"978715311","aktoerType":"ORGANISASJON"},"virksomhet":{"identifikator":"972674818","aktoerType":"ORGANISASJON"},"inntektsmottaker":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"},"inngaarIGrunnlagForTrekk":true,"utloeserArbeidsgiveravgift":true,"informasjonsstatus":"InngaarAlltid","beskrivelse":"feriepenger"},{"inntektType":"LOENNSINNTEKT","beloep":31868.25,"fordel":"kontantytelse","inntektskilde":"A-ordningen","inntektsperiodetype":"Maaned","inntektsstatus":"LoependeInnrapportert","leveringstidspunkt":"2022-08","utbetaltIMaaned":"2022-11","opplysningspliktig":{"identifikator":"978715311","aktoerType":"ORGANISASJON"},"virksomhet":{"identifikator":"972674818","aktoerType":"ORGANISASJON"},"inntektsmottaker":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"},"inngaarIGrunnlagForTrekk":true,"utloeserArbeidsgiveravgift":true,"informasjonsstatus":"InngaarAlltid","beskrivelse":"fastloenn"}],"forskuddstrekkListe":[{"beloep":-544,"leveringstidspunkt":"2022-08-16T13:29:32.664","opplysningspliktig":{"identifikator":"936164226","aktoerType":"ORGANISASJON"},"utbetaler":{"identifikator":"873174242","aktoerType":"ORGANISASJON"},"forskuddstrekkGjelder":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"}}],"fradragListe":[{"beloep":-638,"beskrivelse":"premieTilPensjonsordninger","fradragsperiode":"2022-11","leveringstidspunkt":"2022-08-16T13:29:32.664","inntektspliktig":{"identifikator":"978715311","aktoerType":"ORGANISASJON"},"utbetaler":{"identifikator":"972674818","aktoerType":"ORGANISASJON"},"fradragGjelder":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"}}]}},{"aarMaaned":"2022-12","arbeidsInntektInformasjon":{"inntektListe":[{"inntektType":"LOENNSINNTEKT","beloep":329,"fordel":"naturalytelse","inntektskilde":"A-ordningen","inntektsperiodetype":"Maaned","inntektsstatus":"LoependeInnrapportert","leveringstidspunkt":"2022-08","utbetaltIMaaned":"2022-12","opplysningspliktig":{"identifikator":"978715311","aktoerType":"ORGANISASJON"},"virksomhet":{"identifikator":"972674818","aktoerType":"ORGANISASJON"},"inntektsmottaker":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"},"inngaarIGrunnlagForTrekk":true,"utloeserArbeidsgiveravgift":true,"informasjonsstatus":"InngaarAlltid","beskrivelse":"annet"},{"inntektType":"LOENNSINNTEKT","beloep":31868.25,"fordel":"kontantytelse","inntektskilde":"A-ordningen","inntektsperiodetype":"Maaned","inntektsstatus":"LoependeInnrapportert","leveringstidspunkt":"2022-08","utbetaltIMaaned":"2022-12","opplysningspliktig":{"identifikator":"978715311","aktoerType":"ORGANISASJON"},"virksomhet":{"identifikator":"972674818","aktoerType":"ORGANISASJON"},"inntektsmottaker":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"},"inngaarIGrunnlagForTrekk":true,"utloeserArbeidsgiveravgift":true,"informasjonsstatus":"InngaarAlltid","beskrivelse":"fastloenn"},{"inntektType":"LOENNSINNTEKT","beloep":1600,"fordel":"kontantytelse","inntektskilde":"A-ordningen","inntektsperiodetype":"Maaned","inntektsstatus":"LoependeInnrapportert","leveringstidspunkt":"2022-08","utbetaltIMaaned":"2022-12","opplysningspliktig":{"identifikator":"936164226","aktoerType":"ORGANISASJON"},"virksomhet":{"identifikator":"873174242","aktoerType":"ORGANISASJON"},"inntektsmottaker":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"},"inngaarIGrunnlagForTrekk":true,"utloeserArbeidsgiveravgift":true,"informasjonsstatus":"InngaarAlltid","beskrivelse":"fastloenn"}],"forskuddstrekkListe":[{"beloep":-7820,"leveringstidspunkt":"2022-08-16T13:29:32.664","opplysningspliktig":{"identifikator":"978715311","aktoerType":"ORGANISASJON"},"utbetaler":{"identifikator":"972674818","aktoerType":"ORGANISASJON"},"forskuddstrekkGjelder":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"}},{"beloep":-540,"leveringstidspunkt":"2022-08-16T13:29:32.664","opplysningspliktig":{"identifikator":"936164226","aktoerType":"ORGANISASJON"},"utbetaler":{"identifikator":"873174242","aktoerType":"ORGANISASJON"},"forskuddstrekkGjelder":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"}}],"fradragListe":[{"beloep":-638,"beskrivelse":"premieTilPensjonsordninger","fradragsperiode":"2022-12","leveringstidspunkt":"2022-08-16T13:29:32.664","inntektspliktig":{"identifikator":"978715311","aktoerType":"ORGANISASJON"},"utbetaler":{"identifikator":"972674818","aktoerType":"ORGANISASJON"},"fradragGjelder":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"}},{"beloep":-9.93,"beskrivelse":"premieTilPensjonsordninger","fradragsperiode":"2022-12","leveringstidspunkt":"2022-08-16T13:29:32.664","inntektspliktig":{"identifikator":"936164226","aktoerType":"ORGANISASJON"},"utbetaler":{"identifikator":"873174242","aktoerType":"ORGANISASJON"},"fradragGjelder":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"}}]}}],
-          "ident":{"identifikator":"08098613316","aktoerType":"NATURLIG_IDENT"}
+          "arbeidsInntektMaaned": [
+            {
+              "aarMaaned": "2022-11",
+              "arbeidsInntektInformasjon": {
+                "inntektListe": [
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 1584,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-08",
+                    "utbetaltIMaaned": "2022-11",
+                    "opplysningspliktig": {
+                      "identifikator": "936164226",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "873174242",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "feriepenger"
+                  },
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 1600,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-08",
+                    "utbetaltIMaaned": "2022-11",
+                    "opplysningspliktig": {
+                      "identifikator": "936164226",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "873174242",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "fastloenn"
+                  },
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": -36765.4,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-08",
+                    "utbetaltIMaaned": "2022-11",
+                    "opplysningspliktig": {
+                      "identifikator": "978715311",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "trekkILoennForFerie"
+                  },
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 329,
+                    "fordel": "naturalytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-08",
+                    "utbetaltIMaaned": "2022-11",
+                    "opplysningspliktig": {
+                      "identifikator": "978715311",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "annet"
+                  },
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 42273.71,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-08",
+                    "utbetaltIMaaned": "2022-11",
+                    "opplysningspliktig": {
+                      "identifikator": "978715311",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "feriepenger"
+                  },
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 31868.25,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-08",
+                    "utbetaltIMaaned": "2022-11",
+                    "opplysningspliktig": {
+                      "identifikator": "978715311",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "fastloenn"
+                  }
+                ],
+                "forskuddstrekkListe": [
+                  {
+                    "beloep": -544,
+                    "leveringstidspunkt": "2022-08-16T13:29:32.664",
+                    "opplysningspliktig": {
+                      "identifikator": "936164226",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "utbetaler": {
+                      "identifikator": "873174242",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "forskuddstrekkGjelder": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    }
+                  }
+                ],
+                "fradragListe": [
+                  {
+                    "beloep": -638,
+                    "beskrivelse": "premieTilPensjonsordninger",
+                    "fradragsperiode": "2022-11",
+                    "leveringstidspunkt": "2022-08-16T13:29:32.664",
+                    "inntektspliktig": {
+                      "identifikator": "978715311",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "utbetaler": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "fradragGjelder": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "aarMaaned": "2022-12",
+              "arbeidsInntektInformasjon": {
+                "inntektListe": [
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 329,
+                    "fordel": "naturalytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-08",
+                    "utbetaltIMaaned": "2022-12",
+                    "opplysningspliktig": {
+                      "identifikator": "978715311",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "annet"
+                  },
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 31868.25,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-08",
+                    "utbetaltIMaaned": "2022-12",
+                    "opplysningspliktig": {
+                      "identifikator": "978715311",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "fastloenn"
+                  },
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 1600,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-08",
+                    "utbetaltIMaaned": "2022-12",
+                    "opplysningspliktig": {
+                      "identifikator": "936164226",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "873174242",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "fastloenn"
+                  }
+                ],
+                "forskuddstrekkListe": [
+                  {
+                    "beloep": -7820,
+                    "leveringstidspunkt": "2022-08-16T13:29:32.664",
+                    "opplysningspliktig": {
+                      "identifikator": "978715311",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "utbetaler": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "forskuddstrekkGjelder": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    }
+                  },
+                  {
+                    "beloep": -540,
+                    "leveringstidspunkt": "2022-08-16T13:29:32.664",
+                    "opplysningspliktig": {
+                      "identifikator": "936164226",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "utbetaler": {
+                      "identifikator": "873174242",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "forskuddstrekkGjelder": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    }
+                  }
+                ],
+                "fradragListe": [
+                  {
+                    "beloep": -638,
+                    "beskrivelse": "premieTilPensjonsordninger",
+                    "fradragsperiode": "2022-12",
+                    "leveringstidspunkt": "2022-08-16T13:29:32.664",
+                    "inntektspliktig": {
+                      "identifikator": "978715311",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "utbetaler": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "fradragGjelder": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    }
+                  },
+                  {
+                    "beloep": -9.93,
+                    "beskrivelse": "premieTilPensjonsordninger",
+                    "fradragsperiode": "2022-12",
+                    "leveringstidspunkt": "2022-08-16T13:29:32.664",
+                    "inntektspliktig": {
+                      "identifikator": "936164226",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "utbetaler": {
+                      "identifikator": "873174242",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "fradragGjelder": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "ident": {
+            "identifikator": "08098613316",
+            "aktoerType": "NATURLIG_IDENT"
+          }
         },
         "headers": {
           "Content-Type": "application/json",

--- a/src/test/resources/mappings/inntektskomponenten_ferietrekk.json
+++ b/src/test/resources/mappings/inntektskomponenten_ferietrekk.json
@@ -1,0 +1,144 @@
+{
+  "mappings": [
+    {
+      "priority": 1,
+      "request": {
+        "method": "POST",
+        "urlPath": "/inntektskomponenten-ws/rs/api/v1/hentinntektliste",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "ident": {
+                "identifikator": "26089638754",
+                "aktoerType": "NATURLIG_IDENT"
+              },
+              "maanedFom": "2023-06",
+              "maanedTom": "2023-06",
+              "ainntektsfilter": "KontrollArbeidsmarkedstiltakA-inntekt"
+            }
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "arbeidsInntektMaaned": [
+            {
+              "aarMaaned": "2021-06",
+              "arbeidsInntektInformasjon": {
+                "inntektListe": [
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 60000,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-02",
+                    "opptjeningsland": "NO",
+                    "opptjeningsperiodeFom": "2022-06-01",
+                    "opptjeningsperiodeTom": "2022-06-30",
+                    "utbetaltIMaaned": "2021-06",
+                    "opplysningspliktig": {
+                      "identifikator": "928497704",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "fastloenn",
+                    "skatteOgAvgiftsregel": "nettoloenn"
+                  },
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": -7500,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-02",
+                    "opptjeningsland": "NO",
+                    "opptjeningsperiodeFom": "2021-06-06",
+                    "opptjeningsperiodeTom": "2021-06-20",
+                    "skattemessigBosattLand": "NO",
+                    "utbetaltIMaaned": "2021-06",
+                    "opplysningspliktig": {
+                      "identifikator": "928497704",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "tilleggsinformasjon": {
+                      "kategori": "NorskKontinentalsokkel"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "trekkILoennForFerie"
+                  },
+                  {
+                    "inntektType": "LOENNSINNTEKT",
+                    "beloep": 5000,
+                    "fordel": "kontantytelse",
+                    "inntektskilde": "A-ordningen",
+                    "inntektsperiodetype": "Maaned",
+                    "inntektsstatus": "LoependeInnrapportert",
+                    "leveringstidspunkt": "2022-02",
+                    "opptjeningsland": "NO",
+                    "opptjeningsperiodeFom": "2021-06-06",
+                    "opptjeningsperiodeTom": "2021-06-20",
+                    "skattemessigBosattLand": "NO",
+                    "utbetaltIMaaned": "2021-06",
+                    "opplysningspliktig": {
+                      "identifikator": "928497704",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "virksomhet": {
+                      "identifikator": "972674818",
+                      "aktoerType": "ORGANISASJON"
+                    },
+                    "tilleggsinformasjon": {
+                      "kategori": "NorskKontinentalsokkel"
+                    },
+                    "inntektsmottaker": {
+                      "identifikator": "08098613316",
+                      "aktoerType": "NATURLIG_IDENT"
+                    },
+                    "inngaarIGrunnlagForTrekk": true,
+                    "utloeserArbeidsgiveravgift": true,
+                    "informasjonsstatus": "InngaarAlltid",
+                    "beskrivelse": "trekkILoennForFerie"
+                  }
+                ]
+              }
+            }
+          ],
+          "ident": {
+            "identifikator": "08098613316",
+            "aktoerType": "NATURLIG_IDENT"
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+          "Nav-consumer-Id": "tiltak-refusjon",
+          "Nav-Call-Id": "hoppla1"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
WIP: Feriepengetrekk kan være både minus og pluss. Det skal alltid rapporteres som minus, men man kan korrigere det ved å rapportere pluss i tillegg.

Ikke ferdig.