### PR TITLE
Lagt til indeks på foreign keys fra refusjon

### DIFF
--- a/src/main/resources/db/migration/V45__index_pa_foreign_keys.sql
+++ b/src/main/resources/db/migration/V45__index_pa_foreign_keys.sql
@@ -1,0 +1,2 @@
+create unique index on refusjon(refusjonsgrunnlag_id);
+create unique index on refusjonsgrunnlag(tilskuddsgrunnlag_id);


### PR DESCRIPTION
Har lagt til indeks på foreign keys fra refusjon->refusjonsgrunnlag->tilskuddsgrunnlag.

Dette bør hjelpe på sequence scans i de vanligste spørringene fra arbeidsgiver.