### PR TITLE
Auditlogging for refusjon-api

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
@@ -7,7 +7,6 @@ import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeGodkj
 import no.nav.security.token.support.core.api.Unprotected
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/Topics.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/Topics.kt
@@ -9,4 +9,5 @@ object Topics {
     const val REFUSJON_ENDRET_BETALINGSSTATUS = "arbeidsgiver.tiltak-refusjon-endret-betalingsstatus"
     const val TILTAK_VARSEL = "arbeidsgiver.tiltak-varsel"
     const val REFUSJON_ENDRET_STATUS = "arbeidsgiver.tiltak-refusjon-endret-status"
+    const val AUDIT_HENDELSE = "arbeidsgiver.tiltak-audit-hendelse"
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/audit/AuditKafkaLogger.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/audit/AuditKafkaLogger.kt
@@ -1,0 +1,30 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.audit
+
+import no.nav.arbeidsgiver.tiltakrefusjon.Topics
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.AuditEntry
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@ConditionalOnProperty("tiltak-refusjon.kafka.enabled")
+@Component
+class AuditKafkaLogger(
+    val auditKafkaTemplate: KafkaTemplate<String, AuditEntry>
+): AuditLogger {
+    var log: Logger = LoggerFactory.getLogger(javaClass)
+
+    override fun logg(event: AuditEntry) {
+        auditKafkaTemplate.send(Topics.AUDIT_HENDELSE, event)
+            .whenComplete { it, ex ->
+                if (ex != null) {
+                    log.error(
+                        "Audit-hendelse kunne ikke sendes til Kafka topic {}",
+                        Topics.AUDIT_HENDELSE,
+                        ex
+                    )
+                }
+            }
+    }
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/audit/AuditLogger.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/audit/AuditLogger.kt
@@ -1,0 +1,29 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.audit
+
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjon
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.AuditEntry
+import org.slf4j.MDC
+import org.springframework.http.HttpMethod
+import java.net.URI
+import java.time.Instant
+
+interface AuditLogger {
+    fun logg(event: AuditEntry)
+
+    fun logg(brukerId: String, melding: String, uri: URI, metode: HttpMethod, vararg refusjoner: Refusjon) {
+        val oppslagsTid = Instant.now()
+        val traceId = MDC.get("traceId")
+        refusjoner.map { it.deltakerFnr }.distinct().forEach {
+            logg(AuditEntry(brukerId, it, oppslagsTid, melding, uri, metode, traceId))
+        }
+    }
+
+    fun logg(brukerId: String, melding: String, uri: URI, metode: HttpMethod, vararg korreksjoner: Korreksjon) {
+        val oppslagsTid = Instant.now()
+        val traceId = MDC.get("traceId")
+        korreksjoner.map { it.deltakerFnr }.distinct().forEach {
+            logg(AuditEntry(brukerId, it, oppslagsTid, melding, uri, metode, traceId))
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/audit/AuditVoidLogger.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/audit/AuditVoidLogger.kt
@@ -1,0 +1,11 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.audit
+
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.AuditEntry
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@ConditionalOnProperty("tiltak-refusjon.kafka.enabled", havingValue = "false", matchIfMissing = true)
+@Component
+class AuditVoidLogger: AuditLogger {
+    override fun logg(event: AuditEntry) {}
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -73,11 +73,11 @@ data class InnloggetSaksbehandler(
 
         val refusjonerMedTilgang = liste.content.filter { abacTilgangsstyringService.harLeseTilgang(identifikator, it.deltakerFnr) }
         val response = mapOf(
-            Pair("refusjoner", refusjonerMedTilgang),
-            Pair("size", liste.size),
-            Pair("currentPage", liste.number),
-            Pair("totalItems", liste.totalElements),
-            Pair("totalPages", liste.totalPages)
+            "refusjoner" to refusjonerMedTilgang,
+            "size" to liste.size,
+            "currentPage" to liste.number,
+            "totalItems" to liste.totalElements,
+            "totalPages" to liste.totalPages
         )
         return response
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/FakeInntektskomponentService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/FakeInntektskomponentService.kt
@@ -8,7 +8,6 @@ import java.time.LocalDate
 import java.time.Period
 import java.time.YearMonth
 import java.time.temporal.TemporalAdjusters
-import kotlin.streams.toList
 
 @Service
 @ConditionalOnProperty("tiltak-refusjon.inntektskomponenten.fake")

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverKorreksjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverKorreksjonController.kt
@@ -1,11 +1,14 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
+import no.nav.arbeidsgiver.tiltakrefusjon.audit.AuditLogger
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBrukerService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.HttpMethod
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 const val REQUEST_MAPPING_ARBEIDSGIVER_KORREKSJON = "/api/arbeidsgiver/korreksjon"
 
@@ -14,11 +17,16 @@ const val REQUEST_MAPPING_ARBEIDSGIVER_KORREKSJON = "/api/arbeidsgiver/korreksjo
 @ProtectedWithClaims(issuer = "tokenx")
 class ArbeidsgiverKorreksjonController(
     val innloggetBrukerService: InnloggetBrukerService,
+    val auditLogger: AuditLogger
 ) {
     @GetMapping("/{id}")
     fun hent(@PathVariable id: String): Korreksjon? {
         val arbeidsgiver = innloggetBrukerService.hentInnloggetArbeidsgiver()
-        return arbeidsgiver.finnKorreksjon(id)
+        val korreksjon = arbeidsgiver.finnKorreksjon(id)
+
+        auditLogger.logg(arbeidsgiver.identifikator, "Hent korreksjon for refusjon", URI.create("$REQUEST_MAPPING_ARBEIDSGIVER_KORREKSJON/ID"), HttpMethod.GET, korreksjon)
+
+        return korreksjon
     }
 
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonKafkaProducer.kt
@@ -3,8 +3,8 @@ package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 import no.nav.arbeidsgiver.tiltakrefusjon.Topics
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.RefusjonGodkjentMelding.Companion.create
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.*
-import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeAnnullertMelding
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.MidlerFrigjortÅrsak
+import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeAnnullertMelding
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -20,19 +20,18 @@ class RefusjonKafkaProducer(
     val tilskuddperiodeAnnullertKafkaTemplate: KafkaTemplate<String, TilskuddsperiodeAnnullertMelding>,
     val refusjonEndretStatusKafkaTemplate: KafkaTemplate<String, RefusjonEndretStatusMelding>
 ) {
-
     var log: Logger = LoggerFactory.getLogger(javaClass)
-
     @TransactionalEventListener
     fun refusjonGodkjent(event: GodkjentAvArbeidsgiver) {
         val melding = create(event.refusjon)
         refusjonGodkjentkafkaTemplate.send(Topics.REFUSJON_GODKJENT, event.refusjon.id, melding)
             .whenComplete { it, ex ->
                 if (ex != null) {
-                    log.warn(
+                    log.error(
                         "Melding med id {} kunne ikke sendes til Kafka topic {}",
                         event.refusjon.id,
-                        Topics.REFUSJON_GODKJENT
+                        Topics.REFUSJON_GODKJENT,
+                        ex
                     )
                 } else {
                     log.info("Melding med id {} sendt til Kafka topic {}", it.producerRecord.key(), Topics.REFUSJON_GODKJENT)
@@ -57,7 +56,7 @@ class RefusjonKafkaProducer(
         korreksjonKafkaTemplate.send(Topics.REFUSJON_KORRIGERT, event.korreksjon.id, melding)
             .whenComplete { it, ex ->
                 if (ex != null) {
-                    log.warn("Feil ved sending av refusjon korrigert-melding på Kafka", it)
+                    log.error("Feil ved sending av refusjon korrigert-melding på Kafka", ex)
                 } else {
                     log.info(
                         "Melding med id {} sendt til Kafka topic {}",
@@ -82,7 +81,7 @@ class RefusjonKafkaProducer(
         )
             .whenComplete { it, ex ->
                 if (ex != null) {
-                    log.warn("Feil ved sending av tilskuddsperiode annullert melding på Kafka", it)
+                    log.error("Feil ved sending av tilskuddsperiode annullert melding på Kafka", ex)
                 } else {
                     log.info(
                         "Melding med id {} sendt til Kafka topic {}",
@@ -107,7 +106,7 @@ class RefusjonKafkaProducer(
         )
             .whenComplete { it, ex ->
                 if (ex != null) {
-                    log.warn("Feil ved sending av tilskuddsperiode annullert melding på Kafka", it)
+                    log.error("Feil ved sending av tilskuddsperiode annullert melding på Kafka", ex)
                 } else {
                     log.info(
                         "Melding med id {} sendt til Kafka topic {}",
@@ -141,7 +140,7 @@ class RefusjonKafkaProducer(
             tilskuddperiodeAnnullertMelding
         ).whenComplete { it, ex ->
             if (ex != null) {
-                log.warn("Feil ved sending av tilskuddsperiode annullert melding på Kafka", it)
+                log.error("Feil ved sending av tilskuddsperiode annullert melding på Kafka", ex)
             } else {
                 log.info(
                     "Melding med id {} sendt til Kafka topic {}",
@@ -168,7 +167,7 @@ class RefusjonKafkaProducer(
             melding
         ).whenComplete { it, ex ->
             if (ex != null) {
-                log.warn("Feil ved sending av refusjon status på Kafka", it)
+                log.error("Feil ved sending av refusjon status på Kafka", ex)
             } else {
                 log.info("Melding med id {} sendt til Kafka topic {}", it?.producerRecord?.key(), it?.recordMetadata?.topic())
             }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
@@ -1,10 +1,12 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
+import no.nav.arbeidsgiver.tiltakrefusjon.audit.AuditLogger
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBrukerService
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.ForlengFristRequest
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.springframework.data.domain.Page
+import org.springframework.http.HttpMethod
 import org.springframework.web.bind.annotation.*
+import java.net.URI
 
 const val REQUEST_MAPPING_SAKSBEHANDLER_REFUSJON = "/api/saksbehandler/refusjon"
 
@@ -27,23 +29,34 @@ data class MerkForUnntakOmInntekterToMånederFremRequest(val merking: Int)
 @ProtectedWithClaims(issuer = "aad")
 class SaksbehandlerRefusjonController(
     val innloggetBrukerService: InnloggetBrukerService,
+    val auditLogger: AuditLogger
 ) {
     @GetMapping
     fun hentAlle(queryParametre: HentSaksbehandlerRefusjonerQueryParametre): Map<String, Any> {
         val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler()
-        return saksbehandler.finnAlle(queryParametre)
+        val resultat = saksbehandler.finnAlle(queryParametre)
+        auditLogger.logg(saksbehandler.identifikator, "Hent refusjonsliste", URI.create(REQUEST_MAPPING_ARBEIDSGIVER_REFUSJON), HttpMethod.GET, *(resultat.get("refusjoner") as List<Refusjon>).toTypedArray())
+        return resultat
     }
 
     @GetMapping("/{id}")
     fun hent(@PathVariable id: String): Refusjon? {
         val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler()
-        return saksbehandler.finnRefusjon(id)
+        val refusjon = saksbehandler.finnRefusjon(id)
+        auditLogger.logg(
+            saksbehandler.identifikator, "Hent detaljer om refusjon", URI.create("$REQUEST_MAPPING_ARBEIDSGIVER_REFUSJON/ID"), HttpMethod.GET, refusjon
+        )
+        return refusjon
     }
 
     @PostMapping("/{id}/forleng-frist")
     fun forlengFrist(@PathVariable id: String, @RequestBody request: ForlengFristRequest): Refusjon {
         val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler()
-        return saksbehandler.forlengFrist(id, request.nyFrist, request.årsak)
+        val refusjon = saksbehandler.forlengFrist(id, request.nyFrist, request.årsak)
+        auditLogger.logg(
+            saksbehandler.identifikator, "Forleng frist for refusjon", URI.create("$REQUEST_MAPPING_ARBEIDSGIVER_REFUSJON/ID/forleng-frist"), HttpMethod.POST, refusjon
+        )
+        return refusjon
     }
 
     @PostMapping("/{id}/merk-for-unntak-om-inntekter-to-mnd-frem")

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/AuditEntry.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/AuditEntry.kt
@@ -1,0 +1,15 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
+
+import org.springframework.http.HttpMethod
+import java.net.URI
+import java.time.Instant
+
+data class AuditEntry(
+    val utførtAv: String, // Nav-ident eller fnr på arbeidsgiver
+    val oppslagPå: String, // Fnr på person det gjøres oppslag på, eller organisasjon
+    val oppslagUtførtTid: Instant,
+    val beskrivelse: String, // Beskrivelse av hva som er gjort, bør være "menneskelig lesbar"
+    val requestUrl: URI,
+    val requestMethod: HttpMethod,
+    val callId: String
+)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/varsling/RefusjonVarselProducer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/varsling/RefusjonVarselProducer.kt
@@ -5,9 +5,7 @@ import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.kafka.core.KafkaTemplate
-import org.springframework.kafka.support.SendResult
 import org.springframework.stereotype.Component
-import org.springframework.util.concurrent.ListenableFutureCallback
 import java.time.LocalDate
 
 @ConditionalOnProperty("tiltak-refusjon.kafka.enabled")

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/NoOpenTelemetryConfiguration.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/NoOpenTelemetryConfiguration.kt
@@ -1,0 +1,26 @@
+package no.nav.arbeidsgiver.tiltakrefusjon
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.*
+
+@Profile("local")
+@Configuration
+class NoOpenTelemetryConfiguration {
+
+    // OpenTelemetry-beans leverer traceId. I lokal modus må vi levere traceId selv.
+    @Bean
+    fun traceIdProvider(): OncePerRequestFilter =
+        object : OncePerRequestFilter() {
+            override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
+                MDC.put("traceId", UUID.randomUUID().toString())
+                filterChain.doFilter(request, response)
+            }
+        }
+}

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/AbacTilgangsstyringServiceTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/AbacTilgangsstyringServiceTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.client.HttpClientErrorException

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonberegnerFratrekkFerieTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonberegnerFratrekkFerieTest.kt
@@ -20,7 +20,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverRefusjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverRefusjonControllerTest.kt
@@ -1,42 +1,66 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 import com.github.guepardoapps.kulid.ULID
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import no.nav.arbeidsgiver.tiltakrefusjon.RessursFinnesIkkeException
 import no.nav.arbeidsgiver.tiltakrefusjon.`Suzanna Hansen`
+import no.nav.arbeidsgiver.tiltakrefusjon.audit.AuditVoidLogger
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetArbeidsgiver
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBrukerService
 import no.nav.arbeidsgiver.tiltakrefusjon.dokgen.DokgenService
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.slf4j.MDC
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import java.util.*
 
-class ArbeidsgiverRefusjonControllerTest{
-
+class ArbeidsgiverRefusjonControllerTest {
 
     lateinit var controller: ArbeidsgiverRefusjonController
-    var innlogetServiceMock = mockk<InnloggetBrukerService>()
-    var dokgenService =    mockk<DokgenService>()
-    var innloggetArbeidsgiver =    mockk<InnloggetArbeidsgiver>()
-    @Before
-    fun setup(){
-        controller = ArbeidsgiverRefusjonController(innlogetServiceMock,dokgenService)
+
+    val voidLogger = spyk<AuditVoidLogger>()
+    val innloggetServiceMock = mockk<InnloggetBrukerService>()
+    val dokgenService = mockk<DokgenService>()
+    val innloggetArbeidsgiver = mockk<InnloggetArbeidsgiver>()
+
+    @BeforeEach
+    fun beforeEach() {
+        controller = ArbeidsgiverRefusjonController(innloggetServiceMock, voidLogger, dokgenService)
+        resetAuditCount()
+        MDC.put("traceId", UUID.randomUUID().toString())
+    }
+
+    @AfterEach
+    fun afterEach() {
+        MDC.remove("traceId")
+    }
+
+    private fun resetAuditCount() {
+        clearMocks(voidLogger)
+        every {
+            voidLogger.logg(any())
+        } returns Unit
     }
 
     @Test
-    fun `test at pdf controller endepunkt ikke spitter ut noe om den ikke finnes`(){
+    fun `test at pdf controller endepunkt ikke spitter ut noe om den ikke finnes`() {
         assertThat(controller.hentPDF("").body).isNull()
     }
-    @Test
-    fun `test at pdf controller endepunkt returnerer pdf som bytearray`(){
 
-        every{innlogetServiceMock.hentInnloggetArbeidsgiver()} returns innloggetArbeidsgiver
-        every{innloggetArbeidsgiver.finnRefusjon(any())} returns `Suzanna Hansen`()
-        every{dokgenService.refusjonPdf(any())} returns ByteArray(1)
+    @Test
+    fun `test at pdf controller endepunkt returnerer pdf som bytearray`() {
+
+        every { innloggetServiceMock.hentInnloggetArbeidsgiver() } returns innloggetArbeidsgiver
+        every { innloggetArbeidsgiver.finnRefusjon(any()) } returns `Suzanna Hansen`()
+        every { innloggetArbeidsgiver.identifikator } returns "01010112345"
+        every { dokgenService.refusjonPdf(any()) } returns ByteArray(1)
 
 
         val forventetHeaders = HttpHeaders()
@@ -50,13 +74,13 @@ class ArbeidsgiverRefusjonControllerTest{
     }
 
     @Test
-    fun `test at pdf controller endepunkt ikke finner refusjon`(){
+    fun `test at pdf controller endepunkt ikke finner refusjon`() {
 
-        every{innlogetServiceMock.hentInnloggetArbeidsgiver()} returns innloggetArbeidsgiver
-        every{innloggetArbeidsgiver.finnRefusjon(any())} throws RessursFinnesIkkeException()
+        every { innloggetServiceMock.hentInnloggetArbeidsgiver() } returns innloggetArbeidsgiver
+        every { innloggetArbeidsgiver.finnRefusjon(any()) } throws RessursFinnesIkkeException()
 
 
-        assertThrows<RessursFinnesIkkeException> {controller.hentPDF(ULID.random())  }
+        assertThrows<RessursFinnesIkkeException> { controller.hentPDF(ULID.random()) }
 
     }
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/InntektslinjeTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/InntektslinjeTest.kt
@@ -1,11 +1,8 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 import java.time.YearMonth
 
 internal class InntektslinjeTest() {

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonApiTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonApiTest.kt
@@ -2,8 +2,14 @@ package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.every
+import io.mockk.verify
+import io.mockk.clearMocks
+import jakarta.servlet.http.Cookie
 import no.nav.arbeidsgiver.tiltakrefusjon.Feilkode
 import no.nav.arbeidsgiver.tiltakrefusjon.altinn.Organisasjon
+import no.nav.arbeidsgiver.tiltakrefusjon.audit.AuditVoidLogger
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.REQUEST_MAPPING_INNLOGGET_ARBEIDSGIVER
 import no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg.HendelsesloggRepository
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjoner
@@ -28,13 +34,11 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import java.nio.charset.StandardCharsets
-import java.util.*
-import jakarta.servlet.http.Cookie
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse.BodyHandlers
+import java.nio.charset.StandardCharsets
 
 data class InnloggetBrukerTest(val identifikator: String, val organisasjoner: Set<Organisasjon>)
 data class RefusjonlistFraFlereOrgTest(
@@ -61,9 +65,11 @@ class RefusjonApiTest(
     @Autowired val korreksjonRepository: KorreksjonRepository,
     @Autowired val varslingRepository: VarslingRepository
 ) {
-
     private final val TOKEN_X_COOKIE_NAVN = "tokenx-token"
     private final val AAD_COOKIE_NAVN = "aad-token"
+
+    @SpykBean
+    lateinit var voidLogger: AuditVoidLogger
 
     val navCookie = Cookie(AAD_COOKIE_NAVN, lagTokenForNavId("Z123456"))
     val arbGiverCookie = Cookie(TOKEN_X_COOKIE_NAVN, lagTokenForFnr("16120102137"))
@@ -71,6 +77,14 @@ class RefusjonApiTest(
     @BeforeEach
     fun setUp() {
         refusjonRepository.saveAll(refusjoner())
+        resetAuditCount()
+    }
+
+    private fun resetAuditCount() {
+        clearMocks(voidLogger)
+        every {
+            voidLogger.logg(any())
+        } returns Unit
     }
 
     @AfterEach
@@ -86,8 +100,13 @@ class RefusjonApiTest(
     fun `hentAlle() er tilgjengelig for saksbehandler`() {
         val json = sendRequest(get("$REQUEST_MAPPING_SAKSBEHANDLER_REFUSJON?enhet=1000"), navCookie)
         val liste = mapper.readValue(json, object : TypeReference<Map<String, Any>>() {})
-        val refusjoner = liste.get("refusjoner") as List<Refusjon>
+        val refusjoner = liste.get("refusjoner") as List<Map<String, Any>>
         assertFalse(refusjoner.isEmpty())
+
+        // Forventer at oppslag auditlogges, men kun én gang per unike deltaker
+        verify(exactly = refusjoner.map { it.get("deltakerFnr") }.toSet().size) {
+            voidLogger.logg(any())
+        }
     }
 
     @Test
@@ -113,6 +132,11 @@ class RefusjonApiTest(
         // DA
         assertTrue(liste.all { it.bedriftNr == bedriftNr })
         assertEquals(4, liste.size)
+
+        // Forventer at oppslag auditlogges, men kun én gang per unike deltaker
+        verify(exactly = liste.map { it.deltakerFnr }.toSet().size) {
+            voidLogger.logg(any())
+        }
     }
 
 
@@ -124,17 +148,27 @@ class RefusjonApiTest(
 
         // NÅR
         val brukerJson = sendRequest(get("$REQUEST_MAPPING_INNLOGGET_ARBEIDSGIVER/innlogget-bruker"), arbGiverCookie)
+        val bruker: InnloggetBrukerTest = mapper.readValue(brukerJson, object : TypeReference<InnloggetBrukerTest>() {})
         val refusjonJson =
             sendRequest(get("$REQUEST_MAPPING_ARBEIDSGIVER_REFUSJON/hentliste?page=0&size=3"), arbGiverCookie)
+        val refusjonlist: RefusjonlistFraFlereOrgTest = mapper.readValue(refusjonJson, object : TypeReference<RefusjonlistFraFlereOrgTest>() {})
+        verify(exactly = refusjonlist.refusjoner.map { it.deltakerFnr }.toSet().size) {
+            voidLogger.logg(any())
+        }
+        resetAuditCount()
         val refusjonJson2 =
             sendRequest(get("$REQUEST_MAPPING_ARBEIDSGIVER_REFUSJON/hentliste?page=1&size=3"), arbGiverCookie)
+        val refusjonlist2: RefusjonlistFraFlereOrgTest = mapper.readValue(refusjonJson2, object : TypeReference<RefusjonlistFraFlereOrgTest>() {})
+        verify(exactly = refusjonlist2.refusjoner.map { it.deltakerFnr }.toSet().size) {
+            voidLogger.logg(any())
+        }
+        resetAuditCount()
         val refusjonJson3 =
             sendRequest(get("$REQUEST_MAPPING_ARBEIDSGIVER_REFUSJON/hentliste?page=0&size=6"), arbGiverCookie)
-
-        val bruker: InnloggetBrukerTest = mapper.readValue(brukerJson, object : TypeReference<InnloggetBrukerTest>() {})
-        val refusjonlist: RefusjonlistFraFlereOrgTest = mapper.readValue(refusjonJson, object : TypeReference<RefusjonlistFraFlereOrgTest>() {})
-        val refusjonlist2: RefusjonlistFraFlereOrgTest = mapper.readValue(refusjonJson2, object : TypeReference<RefusjonlistFraFlereOrgTest>() {})
         val refusjonlist3: RefusjonlistFraFlereOrgTest = mapper.readValue(refusjonJson3, object : TypeReference<RefusjonlistFraFlereOrgTest>() {})
+        verify(exactly = refusjonlist3.refusjoner.map { it.deltakerFnr }.toSet().size) {
+            voidLogger.logg(any())
+        }
 
         // SÅ
         assertThat(refusjonlist.refusjoner).allMatch { bedrifter -> bruker.organisasjoner.any { it.organizationNumber == bedrifter.bedriftNr } }
@@ -168,6 +202,10 @@ class RefusjonApiTest(
         val json = sendRequest(get("$REQUEST_MAPPING_ARBEIDSGIVER_REFUSJON/$id"), arbGiverCookie)
         val refusjon = mapper.readValue(json, Refusjon::class.java)
         assertEquals(id, refusjon.id)
+
+        verify(exactly = 1) {
+            voidLogger.logg(any())
+        }
     }
 
     @Test
@@ -184,6 +222,10 @@ class RefusjonApiTest(
         val json = sendRequest(get("$REQUEST_MAPPING_SAKSBEHANDLER_REFUSJON/$id"), navCookie)
         val refusjon = mapper.readValue(json, Refusjon::class.java)
         assertEquals(id, refusjon.id)
+
+        verify(exactly = 1) {
+            voidLogger.logg(any())
+        }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import java.lang.RuntimeException
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth


### PR DESCRIPTION
For å gjøre audit-logging mer fleksibelt bruker
vi eksisterende kafka-infrastruktur for å putte
audit-hendelser på en kø som senere fanges opp
av en dedikert applikasjon som dytter data videre
til ArcSight.