### PR TITLE
Grunnleggende funksjonalitet for å kunne godkjenne nullrefusjon

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
@@ -79,6 +79,12 @@ data class InnloggetArbeidsgiver(
         refusjonService.godkjennForArbeidsgiver(refusjon, this.identifikator)
     }
 
+    fun godkjennNullbeløp(refusjonId: String) {
+        val refusjon: Refusjon = refusjonRepository.findByIdOrNull(refusjonId) ?: throw RessursFinnesIkkeException()
+        sjekkHarTilgangTilRefusjonerForBedrift(refusjon.bedriftNr)
+        refusjonService.godkjennNullbeløpForArbeidsgiver(refusjon, this.identifikator)
+    }
+
     fun finnRefusjon(id: String): Refusjon {
         val refusjon: Refusjon = refusjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverRefusjonController.kt
@@ -132,6 +132,13 @@ class ArbeidsgiverRefusjonController(
         arbeidsgiver.godkjenn(id)
     }
 
+    @PostMapping("/{id}/godkjenn-nullbeløp")
+    @Transactional
+    fun godkjennNullbeløp(@PathVariable id: String) {
+        val arbeidsgiver = innloggetBrukerService.hentInnloggetArbeidsgiver()
+        arbeidsgiver.godkjennNullbeløp(id)
+    }
+
     @PostMapping("/{id}/merk-for-hent-inntekter-frem")
     @Transactional
     fun merkForHentInntekterFrem(@PathVariable id: String, @RequestBody request: MerkInntekterFremRequest) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -162,8 +162,6 @@ class Refusjon(
         godkjentAvArbeidsgiver = Now.instant()
         status = RefusjonStatus.SENDT_KRAV
 
-        // Hvordan håndtere at "nullstille" minusbeløp her?
-        // Summere en sorts total?
         if(refusjonsgrunnlag.refusjonsgrunnlagetErNullSomIZero()) {
             status = RefusjonStatus.GODKJENT_NULLBELØP
             registerEvent(RefusjonGodkjentNullBeløp(this, utførtAv))
@@ -174,6 +172,19 @@ class Refusjon(
             registerEvent(GodkjentAvArbeidsgiver(this, utførtAv))
         }
 
+        registerEvent(RefusjonEndretStatus(this))
+    }
+
+    fun godkjennNullbeløpForArbeidsgiver(utførtAv: String) {
+        oppdaterStatus()
+        krevStatus(RefusjonStatus.KLAR_FOR_INNSENDING)
+
+        if(!refusjonsgrunnlag.bedriftKid?.trim().isNullOrEmpty()){
+            KidValidator(refusjonsgrunnlag.bedriftKid)
+        }
+        godkjentAvArbeidsgiver = Now.instant()
+        status = RefusjonStatus.GODKJENT_NULLBELØP
+        registerEvent(RefusjonGodkjentNullBeløp(this, utførtAv))
         registerEvent(RefusjonEndretStatus(this))
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -169,7 +169,6 @@ class RefusjonService(
         sjekkForTrukketFerietrekkForSammeMåned(refusjon)
         refusjon.godkjennForArbeidsgiver(utførtAv)
         if(refusjon.status == RefusjonStatus.GODKJENT_MINUSBELØP) {
-            val alleMinusBeløp = minusbelopRepository.findAllByAvtaleNr(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr)
             alleMinusBeløp.forEach {
                 it.gjortOpp = true
                 it.gjortOppAvRefusjonId = refusjon.id
@@ -179,10 +178,14 @@ class RefusjonService(
                 avtaleNr = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr,
                 beløp = refusjon.refusjonsgrunnlag.beregning?.refusjonsbeløp,
                 løpenummer = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.løpenummer)
-
             refusjon.minusbelop = minusbelop
             log.info("Setter minusbeløp ${minusbelop.id} på refusjon ${refusjon.id}")
         }
+        refusjonRepository.save(refusjon)
+    }
+
+    fun godkjennNullbeløpForArbeidsgiver(refusjon: Refusjon, utførtAv: String) {
+        refusjon.godkjennNullbeløpForArbeidsgiver(utførtAv)
         refusjonRepository.save(refusjon)
     }
 


### PR DESCRIPTION
Håndterer tilfelder hvor arbeidsgiver ikke har, eller ikke velger, inntekter for refusjonen. De kan da godkjenne den med null i beløp sånn at det ikke går ut på tid.

Midler blir frigitt.