### PR TITLE
Korreksjon av en refusjon som gått i minus regnes nå ut riktig

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
@@ -73,7 +73,7 @@ fun beregnRefusjonsbeløp(
 
     val overTilskuddsbeløp = beregnetBeløp > tilskuddsgrunnlag.tilskuddsbeløp
     var refusjonsbeløp =
-        (if (overTilskuddsbeløp) tilskuddsgrunnlag.tilskuddsbeløp.toDouble() else beregnetBeløp) - (if(tidligereUtbetalt < 0) tidligereUtbetalt  * -1 else tidligereUtbetalt) + forrigeRefusjonMinusBeløp
+        (if (overTilskuddsbeløp) tilskuddsgrunnlag.tilskuddsbeløp.toDouble() else beregnetBeløp) - tidligereUtbetalt + forrigeRefusjonMinusBeløp
     var overFemGrunnbeløp = false
     if (tilskuddsgrunnlag.tiltakstype == Tiltakstype.VARIG_LONNSTILSKUDD) {
         if (refusjonsbeløp > gjenståendeEtterMaks5G(sumUtbetaltVarig.toDouble(), tilskuddFom)) {


### PR DESCRIPTION
Korreksjon av en refusjon som går i minus må regnes ut med riktig "tegn" på refusjonsbeløpet. Dette vil gi en totalsum som blir riktig.

Eksempel:
- Refusjonen med 18000 i inntekt og med ferietrekk har fått resultat -5553 kr.
- I korreksjonen velger man 20000 i inntekt, altså  2000 mer. Man forventer da at man får utbetalt litt ekstra (blir skydlig noe mindre)
- Utregningen i korreksjonen blir da (med korreksjonens metadata) 1587 kr
- Da dette blir en utbetalning vil man altså blir skydlig 1587 kr mindre totalt sett.
- Gjenværende minusbeløp på -5553 kr vil fortsatt trekkes en evt fremtidig refusjon. Men totalen blir altså riktig.