### PR TITLE
Admin-endepunkt: Hent refusjoner med status 'sendt krav'

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
@@ -221,6 +221,9 @@ class AdminController(
         return beregning
     }
 
+    @Unprotected
+    @GetMapping("hent-refusjoner-med-status-sendt")
+    fun hentRefusjonerMedStatusSendtKrav()  = refusjonRepository.findAllByStatus(RefusjonStatus.SENDT_KRAV)
 }
 
 data class ReberegnRequest(val harFerietrekkForSammeMåned: Boolean, val minusBeløp: Int, val ferieTrekk: Int)


### PR DESCRIPTION
Dette er for å kunne liste ut og sjekke om det er mismatch i refusjonsløsning og økonomiløsning.