### PR TITLE
Hendelseslogg-modal

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
@@ -1,9 +1,10 @@
 package no.nav.arbeidsgiver.tiltakrefusjon
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.ADMIN_BRUKER
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.leader.LeaderPodCheck
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.*
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.MidlerFrigjortÅrsak
-import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeAnnullertMelding
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeForkortetMelding
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeGodkjentMelding
 import no.nav.security.token.support.core.api.Unprotected
@@ -95,7 +96,7 @@ class AdminController(
                 refusjonRepository.findByIdOrNull(id) ?: throw RuntimeException("Finner ikke refusjon med id=$id")
 
             try {
-                refusjon.forlengFrist(request.nyFrist, request.årsak, "admin", request.enforce)
+                refusjon.forlengFrist(request.nyFrist, request.årsak, ADMIN_BRUKER, request.enforce)
                 refusjonRepository.save(refusjon)
             } catch (e: FeilkodeException) {
                 if (e.feilkode == Feilkode.FOR_LANG_FORLENGELSE_AV_FRIST) {
@@ -111,12 +112,16 @@ class AdminController(
     @PostMapping("forleng-frister-til-og-med-dato")
     fun forlengFristerTilOgMedDato(@RequestBody request: ForlengFristerTilOgMedRequest) {
         logger.info("Bruker AdminController for å forlenge refusjoner med frist før ${request.tilDato} til ny frist: ${request.nyFrist}")
-        val refusjoner = refusjonRepository.findAllByFristForGodkjenningBeforeAndStatus(request.tilDato, RefusjonStatus.KLAR_FOR_INNSENDING)
+        val refusjoner = refusjonRepository.findAllByFristForGodkjenningBeforeAndStatus(
+            request.tilDato,
+            RefusjonStatus.KLAR_FOR_INNSENDING
+        )
         logger.info("Fant ${refusjoner.size} refusjoner som skal forlenges")
         var fristerForlenget = 0
+
         for (refusjon in refusjoner) {
             try {
-                refusjon.forlengFrist(request.nyFrist, request.årsak, "admin", request.enforce)
+                refusjon.forlengFrist(request.nyFrist, request.årsak, ADMIN_BRUKER, request.enforce)
                 refusjonRepository.save(refusjon)
                 fristerForlenget++
             } catch (e: FeilkodeException) {
@@ -134,11 +139,14 @@ class AdminController(
     @Unprotected
     @PostMapping("annuller-tilskuddsperioder-manuelt")
     fun annullerTilskuddsperioderIRefusjonManuelt(@RequestBody request: AnnullerTilskuddsperioderRequest) {
-        logger.info("Bruker AdminController for å annullere tilskuddsperioder i {} refusjoner", request.refusjonIder.size)
+        logger.info(
+            "Bruker AdminController for å annullere tilskuddsperioder i {} refusjoner",
+            request.refusjonIder.size
+        )
         for (id in request.refusjonIder) {
             val refusjon =
                 refusjonRepository.findByIdOrNull(id) ?: throw RuntimeException("Finner ikke refusjon med id=$id")
-            refusjon.annullerTilskuddsperioderIRefusjon(request.utførtAv, request.årsak)
+            refusjon.annullerTilskuddsperioderIRefusjon(opprettAdminbruker(request.utførtAv), request.årsak)
             refusjonRepository.save(refusjon)
         }
     }
@@ -147,9 +155,12 @@ class AdminController(
     @PostMapping("annuller-tilskuddsperioder-manuelt-i-utgåtte-refusjoner")
     fun annullerTilskuddsperioderIUtgåtteRefusjonManuelt(@RequestBody request: AnnullerTilskuddsperioderIUtgåtteRefusjonerRequest) {
         val utgåtteRefusjoner = refusjonRepository.findAllByStatus(RefusjonStatus.UTGÅTT)
-        logger.info("Bruker AdminController for å annullere tilskuddsperioder i {} utgåtte refusjoner", utgåtteRefusjoner.size)
+        logger.info(
+            "Bruker AdminController for å annullere tilskuddsperioder i {} utgåtte refusjoner",
+            utgåtteRefusjoner.size
+        )
         utgåtteRefusjoner.forEach {
-            it.annullerTilskuddsperioderIRefusjon(request.utførtAv, request.årsak)
+            it.annullerTilskuddsperioderIRefusjon(opprettAdminbruker(request.utførtAv), request.årsak)
             refusjonRepository.save(it)
         }
     }
@@ -226,6 +237,15 @@ class AdminController(
     fun hentRefusjonerMedStatusSendtKrav()  = refusjonRepository.findAllByStatus(RefusjonStatus.SENDT_KRAV)
 }
 
+fun opprettAdminbruker(utførtAv: String): InnloggetBruker {
+    return object : InnloggetBruker {
+        override val identifikator: String
+            get() = utførtAv
+        override val rolle: BrukerRolle
+            get() = BrukerRolle.SYSTEM
+    }
+}
+
 data class ReberegnRequest(val harFerietrekkForSammeMåned: Boolean, val minusBeløp: Int, val ferieTrekk: Int)
 
 data class KorreksjonRequest(val refusjonIder: List<String>, val korreksjonsgrunner: Set<Korreksjonsgrunn>)
@@ -233,7 +253,12 @@ data class KorreksjonRequest(val refusjonIder: List<String>, val korreksjonsgrun
 data class ForlengFristerRequest(val refusjonIder: List<String>, val nyFrist: LocalDate, val årsak: String, val enforce: Boolean)
 data class ForlengFristerTilOgMedRequest(val tilDato: LocalDate, val nyFrist: LocalDate, val årsak: String, val enforce: Boolean)
 
-data class AnnullerTilskuddsperioderRequest(val refusjonIder: List<String>, val utførtAv: String, val årsak: String)
+data class AnnullerTilskuddsperioderRequest( //TODO: spør mattias
+    val refusjonIder: List<String>,
+    val utførtAv: String,
+    val årsak: String
+)
+
 data class AnnullerTilskuddsperioderIUtgåtteRefusjonerRequest(val utførtAv: String, val årsak: String)
 
 data class AnnullerRefusjon(val tilskuddsperiodeId: String)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetBruker.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetBruker.kt
@@ -1,0 +1,8 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.autorisering
+
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BrukerRolle
+
+interface InnloggetBruker {
+    val identifikator: String
+    val rolle: BrukerRolle
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/SystemBrukere.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/SystemBrukere.kt
@@ -1,0 +1,24 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.autorisering
+
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BrukerRolle
+
+val KAFKA_BRUKER = object : InnloggetBruker {
+    override val identifikator: String
+        get() = "kafka"
+    override val rolle: BrukerRolle
+        get() = BrukerRolle.SYSTEM
+}
+
+val ADMIN_BRUKER = object : InnloggetBruker {
+    override val identifikator: String
+        get() = "admin"
+    override val rolle: BrukerRolle
+        get() = BrukerRolle.SYSTEM
+}
+
+val SYSTEM_BRUKER = object : InnloggetBruker {
+    override val identifikator: String
+        get() = "system"
+    override val rolle: BrukerRolle
+        get() = BrukerRolle.SYSTEM
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/EndretGrunnlagLytter.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/EndretGrunnlagLytter.kt
@@ -1,7 +1,10 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg
 
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.SaksbehandlerMerketForInntekterLengerFrem
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.SporbarKorreksjonHendelse
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.SporbarRefusjonHendelse
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.SporbarRefusjonVarsel
+import no.nav.arbeidsgiver.tiltakrefusjon.varsling.VarselType
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
@@ -14,13 +17,29 @@ class EndretGrunnlagLytter(
 ) {
     @EventListener
     fun sporbarHendelse(event: SporbarRefusjonHendelse) {
-        val hendelse = Hendelseslogg(
-            appImageId = appImageId,
-            refusjonId = event.refusjon.id,
-            korreksjonId = null,
-            utførtAv = event.utførtAv,
-            event = event.javaClass.simpleName,
-        )
+        val hendelse: Hendelseslogg
+        if (event is SaksbehandlerMerketForInntekterLengerFrem) {
+            hendelse = Hendelseslogg(
+                appImageId = appImageId,
+                refusjonId = event.refusjon.id,
+                korreksjonId = null,
+                utførtAv = event.utførtAv.identifikator,
+                utførtRolle = event.utførtAv.rolle,
+                event = event.javaClass.simpleName,
+                metadata = HendelseMetadata(
+                    antallMndFremITid = event.merking,
+                )
+            )
+        } else {
+            hendelse = Hendelseslogg(
+                appImageId = appImageId,
+                refusjonId = event.refusjon.id,
+                korreksjonId = null,
+                utførtAv = event.utførtAv.identifikator,
+                utførtRolle = event.utførtAv.rolle,
+                event = event.javaClass.simpleName,
+            )
+        }
         hendelsesloggRepository.save(hendelse)
     }
 
@@ -30,8 +49,27 @@ class EndretGrunnlagLytter(
             appImageId = appImageId,
             refusjonId = event.korreksjon.korrigererRefusjonId,
             korreksjonId = event.korreksjon.id,
-            utførtAv = event.utførtAv,
+            utførtAv = event.utførtAv.identifikator,
+            utførtRolle = event.utførtAv.rolle,
             event = event.javaClass.simpleName,
+        )
+        hendelsesloggRepository.save(hendelse)
+    }
+
+    @EventListener
+    fun sporbarHendelse(event: SporbarRefusjonVarsel) {
+        val hendelse = Hendelseslogg(
+            appImageId = appImageId,
+            refusjonId = event.refusjonId,
+            korreksjonId = null,
+            utførtAv = event.utførtAv.identifikator,
+            utførtRolle = event.utførtAv.rolle,
+            event = when (event.varselType) {
+                VarselType.KLAR -> "RefusjonVarselKlar"
+                VarselType.REVARSEL -> "RefusjonVarselRevarsel"
+                VarselType.FRIST_FORLENGET -> "RefusjonVarselFristForlenget"
+                VarselType.KORRIGERT -> "RefusjonVarselKorrigert"
+            }
         )
         hendelsesloggRepository.save(hendelse)
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelseMetadata.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelseMetadata.kt
@@ -1,0 +1,3 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg
+
+data class HendelseMetadata(val antallMndFremITid: Int)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelseMetadataConverter.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelseMetadataConverter.kt
@@ -1,0 +1,20 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+val mapper = jacksonObjectMapper()
+@Converter(autoApply = true)
+class HendelseMetadataConverter: AttributeConverter<HendelseMetadata, String> {
+
+    override fun convertToDatabaseColumn(attribute: HendelseMetadata?): String? =
+        if (attribute == null) null
+        else mapper.writeValueAsString(attribute)
+
+    override fun convertToEntityAttribute(dbData: String?): HendelseMetadata? =
+        if (dbData == null) null
+        else mapper.readValue(dbData, HendelseMetadata::class.java)
+
+
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/Hendelseslogg.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/Hendelseslogg.kt
@@ -24,12 +24,4 @@ data class Hendelseslogg(
     @Id
     val id: String = ulid()
     val tidspunkt: LocalDateTime = Now.localDateTime()
-
-    fun fjernFnrArbeidsgiver(): Hendelseslogg { //TODO: SPør om Odd andreas har noe lurt
-        return if (utførtRolle == BrukerRolle.ARBEIDSGIVER) {
-            this.copy(utførtAv = utførtRolle.name)
-        } else {
-            this
-        }
-    }
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/Hendelseslogg.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/Hendelseslogg.kt
@@ -1,20 +1,35 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg
 
-import jakarta.persistence.Entity
-import jakarta.persistence.Id
+import jakarta.persistence.*
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BrukerRolle
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.ulid
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
 import java.time.LocalDateTime
 
 @Entity
-class Hendelseslogg(
+data class Hendelseslogg(
     val appImageId: String,
     val refusjonId: String,
     val korreksjonId: String?,
     val utførtAv: String,
+    @Enumerated(EnumType.STRING)
+    val utførtRolle: BrukerRolle?,
     val event: String,
+    @Convert(converter = HendelseMetadataConverter::class)
+    @JdbcTypeCode(SqlTypes.JSON)
+    val metadata: HendelseMetadata? = null,
 ) {
     @Id
     val id: String = ulid()
     val tidspunkt: LocalDateTime = Now.localDateTime()
+
+    fun fjernFnrArbeidsgiver(): Hendelseslogg { //TODO: SPør om Odd andreas har noe lurt
+        return if (utførtRolle == BrukerRolle.ARBEIDSGIVER) {
+            this.copy(utførtAv = utførtRolle.name)
+        } else {
+            this
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelsesloggDTO.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelsesloggDTO.kt
@@ -1,0 +1,30 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg
+
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BrukerRolle
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.erGyldigFnr
+import java.time.LocalDateTime
+
+data class HendelsesloggDTO(
+    val refusjonId: String,
+    val korreksjonId: String?,
+    val utførtAv: String,
+    val event: String,
+    val metadata: HendelseMetadata? = null,
+    val tidspunkt: LocalDateTime,
+) {
+    constructor(hendelseslogg: Hendelseslogg) : this(
+        refusjonId = hendelseslogg.refusjonId,
+        korreksjonId = hendelseslogg.korreksjonId,
+        utførtAv = if (hendelseslogg.utførtRolle == BrukerRolle.ARBEIDSGIVER) {
+            hendelseslogg.utførtRolle.name
+        } else if (erGyldigFnr(hendelseslogg.utførtAv)) {
+            // rolle mangler på eldre events
+            ""
+        } else {
+            hendelseslogg.utførtAv
+        },
+        event = hendelseslogg.event,
+        metadata = hendelseslogg.metadata,
+        tidspunkt = hendelseslogg.tidspunkt,
+    )
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/BrukerRolle.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/BrukerRolle.kt
@@ -1,0 +1,8 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
+
+enum class BrukerRolle {
+    ARBEIDSGIVER,
+    VEILEDER,
+    BESLUTTER,
+    SYSTEM,
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/FristForlengetLytter.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/FristForlengetLytter.kt
@@ -21,7 +21,7 @@ class FristForlengetLytter(
                 gammelFrist = event.gammelFrist,
                 nyFrist = event.nyFrist,
                 årsak = event.årsak,
-                utførtAv = event.utførtAv
+                utførtAv = event.utførtAv.identifikator
             )
         )
         producer.sendVarsel(

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.persistence.*
 import no.nav.arbeidsgiver.tiltakrefusjon.Feilkode
 import no.nav.arbeidsgiver.tiltakrefusjon.FeilkodeException
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.KorreksjonBeregningUtført
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.KorreksjonMerketForOppgjort
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.KorreksjonMerketForTilbakekreving
@@ -103,7 +104,7 @@ class Korreksjon(
     }
 
     // Ved positivt beløp, skal etterbetale
-    fun utbetalKorreksjon(utførtAv: String, beslutterNavIdent: String, kostnadssted: String) {
+    fun utbetalKorreksjon(utførtAv: InnloggetBruker, kostnadssted: String) {
         krevStatus(Korreksjonstype.UTKAST)
 
         val refusjonsbeløp = refusjonsgrunnlag.beregning?.refusjonsbeløp
@@ -113,7 +114,7 @@ class Korreksjon(
         if (refusjonsgrunnlag.bedriftKontonummer == null) {
             throw FeilkodeException(Feilkode.INGEN_BEDRIFTKONTONUMMER)
         }
-        if (beslutterNavIdent.isBlank()) {
+        if (utførtAv.identifikator.isBlank()) {
             throw FeilkodeException(Feilkode.INGEN_BESLUTTER)
         }
         if (kostnadssted.isBlank()) {
@@ -124,8 +125,8 @@ class Korreksjon(
         }
 
         this.godkjentTidspunkt = Now.instant()
-        this.godkjentAvNavIdent = utførtAv
-        this.besluttetAvNavIdent = beslutterNavIdent
+        this.godkjentAvNavIdent = utførtAv.identifikator
+        this.besluttetAvNavIdent = utførtAv.identifikator
         this.besluttetTidspunkt = Now.instant()
         this.kostnadssted = kostnadssted
         this.status = Korreksjonstype.TILLEGSUTBETALING
@@ -133,7 +134,7 @@ class Korreksjon(
     }
 
     // Ved 0 beløp, skal ikke tilbakekreve eller etterbetale
-    fun fullførKorreksjonVedOppgjort(utførtAv: String) {
+    fun fullførKorreksjonVedOppgjort(utførtAv: InnloggetBruker) {
         krevStatus(Korreksjonstype.UTKAST)
         val refusjonsbeløp = refusjonsgrunnlag.beregning?.refusjonsbeløp
         if (refusjonsbeløp == null || refusjonsbeløp != 0) {
@@ -143,13 +144,13 @@ class Korreksjon(
             throw FeilkodeException(Feilkode.IKKE_TATT_STILLING_TIL_ALLE_INNTEKTSLINJER)
         }
         this.godkjentTidspunkt = Now.instant()
-        this.godkjentAvNavIdent = utførtAv
+        this.godkjentAvNavIdent = utførtAv.identifikator
         this.status = Korreksjonstype.OPPGJORT
         registerEvent(KorreksjonMerketForOppgjort(this, utførtAv))
     }
 
     // Ved negativt beløp, skal tilbakekreves
-    fun fullførKorreksjonVedTilbakekreving(utførtAv: String) {
+    fun fullførKorreksjonVedTilbakekreving(utførtAv: InnloggetBruker) {
         krevStatus(Korreksjonstype.UTKAST)
         val refusjonsbeløp = refusjonsgrunnlag.beregning?.refusjonsbeløp
         if (refusjonsbeløp == null || refusjonsbeløp >= 0) {
@@ -159,16 +160,16 @@ class Korreksjon(
             throw FeilkodeException(Feilkode.IKKE_TATT_STILLING_TIL_ALLE_INNTEKTSLINJER)
         }
         this.godkjentTidspunkt = Now.instant()
-        this.godkjentAvNavIdent = utførtAv
+        this.godkjentAvNavIdent = utførtAv.identifikator
         this.status = Korreksjonstype.TILBAKEKREVING
         registerEvent(KorreksjonMerketForTilbakekreving(this, utførtAv))
     }
 
-    fun endreBruttolønn(inntekterKunFraTiltaket: Boolean?, endretBruttoLønn: Int?) {
+    fun endreBruttolønn(utførtAv: InnloggetBruker ,inntekterKunFraTiltaket: Boolean?, endretBruttoLønn: Int?) {
         krevStatus(Korreksjonstype.UTKAST)
         val harGjortBeregning = refusjonsgrunnlag.endreBruttolønn(inntekterKunFraTiltaket, endretBruttoLønn)
         if (harGjortBeregning) {
-            registerEvent(KorreksjonBeregningUtført(this))
+            registerEvent(KorreksjonBeregningUtført(this, utførtAv))
         }
     }
 
@@ -185,33 +186,33 @@ class Korreksjon(
         return status == Korreksjonstype.UTKAST
     }
 
-    fun oppgiInntektsgrunnlag(inntektsgrunnlag: Inntektsgrunnlag) {
+    fun oppgiInntektsgrunnlag(utførtAv: InnloggetBruker, inntektsgrunnlag: Inntektsgrunnlag) {
         val harGjortBeregning = this.refusjonsgrunnlag.oppgiInntektsgrunnlag(inntektsgrunnlag, this.refusjonsgrunnlag.inntektsgrunnlag)
         if (harGjortBeregning) {
-            registerEvent(KorreksjonBeregningUtført(this))
+            registerEvent(KorreksjonBeregningUtført(this, utførtAv))
         }
     }
 
-    fun oppgiBedriftKontonummer(bedrifKontonummer: String) {
+    fun oppgiBedriftKontonummer(utførtAv: InnloggetBruker, bedrifKontonummer: String) {
         val harGjortBeregning = this.refusjonsgrunnlag.oppgiBedriftKontonummer(bedrifKontonummer)
         if (harGjortBeregning) {
-            registerEvent(KorreksjonBeregningUtført(this))
+            registerEvent(KorreksjonBeregningUtført(this, utførtAv))
         }
     }
 
-    fun setInntektslinjeTilOpptjentIPeriode(inntekslinjeId: String, erOpptjentIPeriode: Boolean) {
+    fun setInntektslinjeTilOpptjentIPeriode(utførtAv: InnloggetBruker ,inntekslinjeId: String, erOpptjentIPeriode: Boolean) {
         krevStatus(Korreksjonstype.UTKAST)
         val harGjortBeregning = refusjonsgrunnlag.setInntektslinjeTilOpptjentIPeriode(inntekslinjeId, erOpptjentIPeriode)
         if (harGjortBeregning) {
-            registerEvent(KorreksjonBeregningUtført(this))
+            registerEvent(KorreksjonBeregningUtført(this, utførtAv))
         }
     }
 
-    fun settFratrekkRefunderbarBeløp(fratrekkRefunderbarBeløp: Boolean, refunderbarBeløp: Int?) {
+    fun settFratrekkRefunderbarBeløp(utførtAv: InnloggetBruker, fratrekkRefunderbarBeløp: Boolean, refunderbarBeløp: Int?) {
         krevStatus(Korreksjonstype.UTKAST)
         val harGjortBeregning = refusjonsgrunnlag.settFratrekkRefunderbarBeløp(fratrekkRefunderbarBeløp, refunderbarBeløp)
         if (harGjortBeregning) {
-            registerEvent(KorreksjonBeregningUtført(this))
+            registerEvent(KorreksjonBeregningUtført(this, utførtAv))
         }
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -218,14 +218,6 @@ class Refusjon(
         registerEvent(RefusjonEndretStatus(this))
     }
 
-    fun annullerTilskuddsperioderIRefusjon(utførtAv: InnloggetBruker, grunn: String) {
-        // Midler som er holdt av skal frigjøres når refusjonsfristen er utgått. enten manuelt eller automatisk.
-        // Foreløpig kun manuelt.
-        oppdaterStatus()
-        krevStatus(RefusjonStatus.UTGÅTT)
-        registerEvent(TilskuddsperioderIRefusjonAnnullertManuelt(this, utførtAv, grunn))
-    }
-
     fun gjørKlarTilInnsending() {
         krevStatus(RefusjonStatus.FOR_TIDLIG)
         if (Now.localDate().isAfter(refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom)) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerKorreksjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerKorreksjonController.kt
@@ -40,7 +40,7 @@ class SaksbehandlerKorreksjonController(
     @PostMapping("/{id}/utbetal-korreksjon")
     fun utbetalKorreksjon(@PathVariable id: String) {
         val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler()
-        return saksbehandler.utbetalKorreksjon(id, saksbehandler.identifikator)
+        return saksbehandler.utbetalKorreksjon(id)
     }
 
     @PostMapping("/{id}/fullfør-korreksjon-ved-oppgjort")

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
@@ -2,7 +2,7 @@ package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 import no.nav.arbeidsgiver.tiltakrefusjon.ReberegnRequest
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBrukerService
-import no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg.Hendelseslogg
+import no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg.HendelsesloggDTO
 import no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg.HendelsesloggRepository
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.ForlengFristRequest
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -44,10 +44,10 @@ class SaksbehandlerRefusjonController(
     }
 
     @GetMapping("/{id}/hendelselogg")
-    fun hentHendelselogg(@PathVariable id: String): List<Hendelseslogg> {
+    fun hentHendelselogg(@PathVariable id: String): List<HendelsesloggDTO> {
         val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler().finnRefusjon(id)
         val hendelser = hendelsesloggRepository.findAll().filter { it.refusjonId == saksbehandler.id }
-        return hendelser.map { it.fjernFnrArbeidsgiver() }
+        return hendelser.map { HendelsesloggDTO(it) }
     }
 
     @PostMapping("/{id}/forleng-frist")

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
@@ -2,9 +2,10 @@ package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 import no.nav.arbeidsgiver.tiltakrefusjon.ReberegnRequest
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBrukerService
+import no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg.Hendelseslogg
+import no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg.HendelsesloggRepository
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.ForlengFristRequest
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.codehaus.plexus.util.StringUtils
 import org.springframework.web.bind.annotation.*
 
 const val REQUEST_MAPPING_SAKSBEHANDLER_REFUSJON = "/api/saksbehandler/refusjon"
@@ -28,6 +29,7 @@ data class MerkForUnntakOmInntekterToMånederFremRequest(val merking: Int)
 @ProtectedWithClaims(issuer = "aad")
 class SaksbehandlerRefusjonController(
     val innloggetBrukerService: InnloggetBrukerService,
+    val hendelsesloggRepository: HendelsesloggRepository,
 ) {
     @GetMapping
     fun hentAlle(queryParametre: HentSaksbehandlerRefusjonerQueryParametre): Map<String, Any> {
@@ -39,6 +41,13 @@ class SaksbehandlerRefusjonController(
     fun hent(@PathVariable id: String): Refusjon? {
         val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler()
         return saksbehandler.finnRefusjon(id)
+    }
+
+    @GetMapping("/{id}/hendelselogg")
+    fun hentHendelselogg(@PathVariable id: String): List<Hendelseslogg> {
+        val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler().finnRefusjon(id)
+        val hendelser = hendelsesloggRepository.findAll().filter { it.refusjonId == saksbehandler.id }
+        return hendelser.map { it.fjernFnrArbeidsgiver() }
     }
 
     @PostMapping("/{id}/forleng-frist")

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/FristForlenget.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/FristForlenget.kt
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 import java.time.LocalDate
 
@@ -8,5 +9,5 @@ data class FristForlenget(
     val gammelFrist: LocalDate,
     val nyFrist: LocalDate,
     val årsak: String,
-    override val utførtAv: String
+    override val utførtAv: InnloggetBruker
 ) : SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/GodkjentAvArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/GodkjentAvArbeidsgiver.kt
@@ -1,6 +1,9 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
-data class GodkjentAvArbeidsgiver(override val refusjon: Refusjon, override val utførtAv: String) :
+data class GodkjentAvArbeidsgiver(
+    override val refusjon: Refusjon, override val utførtAv: InnloggetBruker
+) :
     SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/KorreksjonBeregningUtført.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/KorreksjonBeregningUtført.kt
@@ -1,6 +1,8 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjon
 
-data class KorreksjonBeregningUtført(override val korreksjon: Korreksjon, override val utførtAv: String = "") :
+data class KorreksjonBeregningUtført(override val korreksjon: Korreksjon, override val utførtAv: InnloggetBruker
+) :
     SporbarKorreksjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/KorreksjonMerketForOppgjort.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/KorreksjonMerketForOppgjort.kt
@@ -1,6 +1,8 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjon
 
-data class KorreksjonMerketForOppgjort(override val korreksjon: Korreksjon, override val utførtAv: String) :
+data class KorreksjonMerketForOppgjort(override val korreksjon: Korreksjon, override val utførtAv: InnloggetBruker
+) :
     SporbarKorreksjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/KorreksjonMerketForTilbakekreving.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/KorreksjonMerketForTilbakekreving.kt
@@ -1,6 +1,8 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjon
 
-data class KorreksjonMerketForTilbakekreving(override val korreksjon: Korreksjon, override val utførtAv: String) :
+data class KorreksjonMerketForTilbakekreving(override val korreksjon: Korreksjon, override val utførtAv: InnloggetBruker
+) :
     SporbarKorreksjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/KorreksjonSendtTilUtbetaling.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/KorreksjonSendtTilUtbetaling.kt
@@ -1,8 +1,9 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjon
 
 data class KorreksjonSendtTilUtbetaling(
     override val korreksjon: Korreksjon,
-    override val utførtAv: String
+    override val utførtAv: InnloggetBruker
 ) : SporbarKorreksjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/MerketForInntekterFrem.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/MerketForInntekterFrem.kt
@@ -1,5 +1,7 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
-data class MerketForInntekterFrem(override val refusjon: Refusjon, val merking: Boolean, override val utførtAv: String) : SporbarRefusjonHendelse
+data class MerketForInntekterFrem(override val refusjon: Refusjon, val merking: Boolean, override val utførtAv: InnloggetBruker
+) : SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonAnnullert.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonAnnullert.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
-data class RefusjonAnnullert(override val refusjon: Refusjon, override val utførtAv: String = "Kafka") :
-    SporbarRefusjonHendelse
+data class RefusjonAnnullert(override val refusjon: Refusjon, override val utførtAv: InnloggetBruker,
+) : SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonForkortet.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonForkortet.kt
@@ -1,6 +1,8 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
-data class RefusjonForkortet(override val refusjon: Refusjon, override val utførtAv: String = "Kafka") :
-    SporbarRefusjonHendelse
+data class RefusjonForkortet(
+    override val refusjon: Refusjon, override val utførtAv: InnloggetBruker
+) : SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonGodkjentMinusBeløp.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonGodkjentMinusBeløp.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
-data class RefusjonGodkjentMinusBeløp(override val refusjon: Refusjon, override val utførtAv: String = "System") :
+data class RefusjonGodkjentMinusBeløp(override val refusjon: Refusjon, override val utførtAv: InnloggetBruker) :
     SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonGodkjentNullBeløp.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonGodkjentNullBeløp.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
-data class RefusjonGodkjentNullBeløp(override val refusjon: Refusjon, override val utførtAv: String = "System") :
+data class RefusjonGodkjentNullBeløp(override val refusjon: Refusjon, override val utførtAv: InnloggetBruker) :
     SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonOpprettet.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/RefusjonOpprettet.kt
@@ -3,5 +3,5 @@ package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
-data class BeregningUtført(override val refusjon: Refusjon, override val utførtAv: InnloggetBruker) :
-    SporbarRefusjonHendelse
+data class RefusjonOpprettet(override val refusjon: Refusjon, override val utførtAv: InnloggetBruker
+) : SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/SaksbehandlerMerketForInntekterLengerFrem.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/SaksbehandlerMerketForInntekterLengerFrem.kt
@@ -3,5 +3,5 @@ package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
-data class BeregningUtført(override val refusjon: Refusjon, override val utførtAv: InnloggetBruker) :
-    SporbarRefusjonHendelse
+data class SaksbehandlerMerketForInntekterLengerFrem(override val refusjon: Refusjon, val merking: Int, override val utførtAv: InnloggetBruker,
+) : SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/SendtVarsel.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/SendtVarsel.kt
@@ -1,0 +1,11 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
+
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.SYSTEM_BRUKER
+import no.nav.arbeidsgiver.tiltakrefusjon.varsling.VarselType
+
+data class SendtVarsel(
+    override val refusjonId: String,
+    override val varselType: VarselType,
+    override val utførtAv: InnloggetBruker = SYSTEM_BRUKER
+) : SporbarRefusjonVarsel

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/SporbarRefusjonHendelse.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/SporbarRefusjonHendelse.kt
@@ -1,8 +1,9 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
 interface SporbarRefusjonHendelse {
     val refusjon: Refusjon
-    val utførtAv: String
+    val utførtAv: InnloggetBruker
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/SporbarRefusjonVarsel.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/SporbarRefusjonVarsel.kt
@@ -1,9 +1,10 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
-import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjon
+import no.nav.arbeidsgiver.tiltakrefusjon.varsling.VarselType
 
-interface SporbarKorreksjonHendelse {
-    val korreksjon: Korreksjon
+interface SporbarRefusjonVarsel {
+    val refusjonId: String
     val utførtAv: InnloggetBruker
+    val varselType: VarselType
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/TilskuddsperioderIRefusjonAnnullertManuelt.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/TilskuddsperioderIRefusjonAnnullertManuelt.kt
@@ -1,6 +1,8 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 
-data class TilskuddsperioderIRefusjonAnnullertManuelt(override val refusjon: Refusjon, override val utførtAv: String, val annulleringsgrunn: String) :
+data class TilskuddsperioderIRefusjonAnnullertManuelt(override val refusjon: Refusjon, override val utførtAv: InnloggetBruker, val annulleringsgrunn: String,
+) :
     SporbarRefusjonHendelse

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/varsling/Varsling.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/varsling/Varsling.kt
@@ -4,7 +4,9 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.SendtVarsel
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.ulid
+import org.springframework.data.domain.AbstractAggregateRoot
 import java.time.LocalDateTime
 
 @Entity
@@ -13,7 +15,10 @@ data class Varsling(
     @Enumerated(EnumType.STRING)
     val varselType: VarselType,
     val varselTidspunkt: LocalDateTime,
-) {
+) : AbstractAggregateRoot<Varsling>() {
     @Id
     val id: String = ulid()
+    init {
+        registerEvent(SendtVarsel(this.refusjonId, this.varselType))
+    }
 }

--- a/src/main/resources/db/migration/V49__Lagt_til_kolonne_i_hendelseslogg.sql
+++ b/src/main/resources/db/migration/V49__Lagt_til_kolonne_i_hendelseslogg.sql
@@ -1,0 +1,1 @@
+alter table HENDELSESLOGG add column metadata json default null;

--- a/src/main/resources/db/migration/V50__Lagt_til_rolle_i_hendelseslogg.sql
+++ b/src/main/resources/db/migration/V50__Lagt_til_rolle_i_hendelseslogg.sql
@@ -1,0 +1,1 @@
+alter table HENDELSESLOGG add column UTFØRT_ROLLE text default null;

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.tiltakrefusjon
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.*
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.ulid
@@ -8,6 +9,14 @@ import no.nav.arbeidsgiver.tiltakrefusjon.varsling.Varsling
 import java.time.YearMonth
 import java.time.temporal.TemporalAdjusters.lastDayOfMonth
 
+val innloggetTestbruker = innloggetBruker("testsystem", BrukerRolle.SYSTEM)
+
+fun innloggetBruker(identifikator: String, rolle: BrukerRolle) = object : InnloggetBruker {
+    override val identifikator: String
+        get() = identifikator
+    override val rolle: BrukerRolle
+        get() = rolle
+}
 
 fun enRefusjon(tilskuddsgrunnlag: Tilskuddsgrunnlag = etTilskuddsgrunnlag()): Refusjon {
     val deltakerFnr = "07098142678"
@@ -433,7 +442,7 @@ fun refusjoner(): List<Refusjon> {
 }
 
 private fun Refusjon.medSvarPåInntekter(): Refusjon {
-    this.endreBruttolønn(true, null)
+    this.endreBruttolønn(innloggetTestbruker, true, null)
     return this
 }
 
@@ -696,7 +705,7 @@ fun Refusjon.medInntektsgrunnlag(
     måned: YearMonth = Now.yearMonth(),
     inntektsgrunnlag: Inntektsgrunnlag = etInntektsgrunnlag(måned = måned),
 ): Refusjon {
-    this.oppgiInntektsgrunnlag(inntektsgrunnlag)
+    this.oppgiInntektsgrunnlag(innloggetTestbruker, inntektsgrunnlag)
     return this
 }
 
@@ -704,12 +713,12 @@ fun Refusjon.medStortInntektsgrunnlag(
     måned: YearMonth = Now.yearMonth(),
     inntektsgrunnlag: Inntektsgrunnlag = etStortInntektsgrunnlag(måned = måned),
 ): Refusjon {
-    this.oppgiInntektsgrunnlag(inntektsgrunnlag)
+    this.oppgiInntektsgrunnlag(innloggetTestbruker, inntektsgrunnlag)
     return this
 }
 
 fun Refusjon.medSendtKravFraArbeidsgiver(): Refusjon {
-    this.godkjennForArbeidsgiver("")
+    this.godkjennForArbeidsgiver(innloggetTestbruker)
     return this
 }
 
@@ -731,6 +740,7 @@ fun Refusjon.copy(
 ): Refusjon {
     return Refusjon(tilskuddsgrunnlag, bedriftNr, deltakerFnr)
 }
+
 fun etInntektsgrunnlag(måned: YearMonth = YearMonth.of(2020, 10), opptjentIPeriode: Boolean = true) = Inntektsgrunnlag(
     inntekter = listOf(
         Inntektslinje(

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelsesloggRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelsesloggRepositoryTest.kt
@@ -1,0 +1,38 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg
+
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BrukerRolle
+import no.nav.arbeidsgiver.tiltakrefusjon.utils.ulid
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("local")
+class HendelsesloggRepositoryTest(
+    @Autowired
+    val hendelsesloggRepository: HendelsesloggRepository,
+) {
+    @Test
+    fun `finn refusjon fra tilskuddsperiodeId`() {
+        val id = ulid()
+        val hendelse = Hendelseslogg(
+            refusjonId = id,
+            event = "Hello world",
+            utførtAv = "testrunner",
+            utførtRolle = BrukerRolle.VEILEDER,
+            korreksjonId = null,
+            appImageId = ulid(),
+            metadata = HendelseMetadata(antallMndFremITid = 2),
+        )
+        hendelsesloggRepository.save(hendelse)
+
+        val lagretHendelse =
+            hendelsesloggRepository.findAll().firstOrNull { it.refusjonId == id }
+                ?: fail("Fant ikke hendelse med refusjonsid $id")
+        assertThat(lagretHendelse).isEqualTo(hendelse)
+    }
+
+}

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/KorreksjonTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/KorreksjonTest.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test
 import java.time.YearMonth
 
 class KorreksjonTest {
+    val innloggetBeslutter = innloggetBruker("X123456", BrukerRolle.BESLUTTER)
+
     @Test
     internal fun `kan utbetale når alt er fylt ut`() {
         val tilskuddsgrunnlag = etTilskuddsgrunnlag()
@@ -25,6 +27,7 @@ class KorreksjonTest {
             annenGrunn = null
         )
         korreksjon.oppgiInntektsgrunnlag(
+            innloggetBeslutter,
             etInntektsgrunnlag(
                 måned = YearMonth.of(
                     tilskuddsgrunnlag.tilskuddFom.year,
@@ -32,8 +35,8 @@ class KorreksjonTest {
                 )
             )
         )
-        korreksjon.oppgiBedriftKontonummer("99999999999")
-        korreksjon.utbetalKorreksjon("", "X123456", "1000")
+        korreksjon.oppgiBedriftKontonummer(innloggetBeslutter, "99999999999")
+        korreksjon.utbetalKorreksjon(innloggetBeslutter, "1000")
         assertThat(korreksjon.status).isEqualTo(Korreksjonstype.TILLEGSUTBETALING)
     }
 
@@ -54,6 +57,7 @@ class KorreksjonTest {
             annenGrunn = null
         )
         korreksjon.oppgiInntektsgrunnlag(
+            innloggetBeslutter,
             etInntektsgrunnlag(
                 måned = YearMonth.of(
                     tilskuddsgrunnlag.tilskuddFom.year,
@@ -61,8 +65,8 @@ class KorreksjonTest {
                 )
             )
         )
-        korreksjon.oppgiBedriftKontonummer("99999999999")
-        assertFeilkode(Feilkode.KOSTNADSSTED_MANGLER) { korreksjon.utbetalKorreksjon("", "X123456", "") }
+        korreksjon.oppgiBedriftKontonummer(innloggetBeslutter, "99999999999")
+        assertFeilkode(Feilkode.KOSTNADSSTED_MANGLER) { korreksjon.utbetalKorreksjon(innloggetBeslutter, "") }
     }
 
     @Disabled("Sperrer ikke for dette pt")
@@ -83,6 +87,7 @@ class KorreksjonTest {
             annenGrunn = null
         )
         korreksjon.oppgiInntektsgrunnlag(
+            innloggetBeslutter,
             etInntektsgrunnlag(
                 måned = YearMonth.of(
                     tilskuddsgrunnlag.tilskuddFom.year,
@@ -90,8 +95,10 @@ class KorreksjonTest {
                 )
             )
         )
-        korreksjon.oppgiBedriftKontonummer("99999999999")
-        assertFeilkode(Feilkode.KORREKSJON_KOSTNADSSTED_ANNET_FYLKE) { korreksjon.utbetalKorreksjon("", "X123456", "2009") }
+        korreksjon.oppgiBedriftKontonummer(innloggetBeslutter, "99999999999")
+        assertFeilkode(Feilkode.KORREKSJON_KOSTNADSSTED_ANNET_FYLKE) {
+            korreksjon.utbetalKorreksjon(innloggetBeslutter, "2009")
+        }
     }
 
     @Test
@@ -111,6 +118,7 @@ class KorreksjonTest {
             annenGrunn = null
         )
         korreksjon.oppgiInntektsgrunnlag(
+            innloggetBeslutter,
             etInntektsgrunnlag(
                 måned = YearMonth.of(
                     tilskuddsgrunnlag.tilskuddFom.year,
@@ -118,8 +126,8 @@ class KorreksjonTest {
                 )
             )
         )
-        korreksjon.oppgiBedriftKontonummer("99999999999")
-        korreksjon.utbetalKorreksjon("", "X123456", "1009")
+        korreksjon.oppgiBedriftKontonummer(innloggetBeslutter, "99999999999")
+        korreksjon.utbetalKorreksjon(innloggetBeslutter, "1009")
         assertThat(korreksjon.status).isEqualTo(Korreksjonstype.TILLEGSUTBETALING)
     }
 
@@ -140,6 +148,7 @@ class KorreksjonTest {
             annenGrunn = null
         )
         korreksjon.oppgiInntektsgrunnlag(
+            innloggetBeslutter,
             etInntektsgrunnlag(
                 måned = YearMonth.of(
                     tilskuddsgrunnlag.tilskuddFom.year,
@@ -147,10 +156,10 @@ class KorreksjonTest {
                 )
             )
         )
-        korreksjon.oppgiBedriftKontonummer("99999999999")
-        assertFeilkode(Feilkode.KORREKSJONSBELOP_NEGATIVT) { korreksjon.utbetalKorreksjon("", "X123456", "9999") }
-        assertFeilkode(Feilkode.KORREKSJONSBELOP_IKKE_NULL) { korreksjon.fullførKorreksjonVedOppgjort("") }
-        korreksjon.fullførKorreksjonVedTilbakekreving("")
+        korreksjon.oppgiBedriftKontonummer(innloggetBeslutter, "99999999999")
+        assertFeilkode(Feilkode.KORREKSJONSBELOP_NEGATIVT) { korreksjon.utbetalKorreksjon(innloggetBeslutter, "9999") }
+        assertFeilkode(Feilkode.KORREKSJONSBELOP_IKKE_NULL) { korreksjon.fullførKorreksjonVedOppgjort(innloggetBeslutter) }
+        korreksjon.fullførKorreksjonVedTilbakekreving(innloggetBeslutter)
         assertThat(korreksjon.status).isEqualTo(Korreksjonstype.TILBAKEKREVING)
     }
 
@@ -171,6 +180,7 @@ class KorreksjonTest {
             annenGrunn = null
         )
         korreksjon.oppgiInntektsgrunnlag(
+            innloggetBeslutter,
             etInntektsgrunnlag(
                 måned = YearMonth.of(
                     tilskuddsgrunnlag.tilskuddFom.year,
@@ -178,10 +188,14 @@ class KorreksjonTest {
                 )
             )
         )
-        korreksjon.oppgiBedriftKontonummer("99999999999")
-        assertFeilkode(Feilkode.KORREKSJONSBELOP_NEGATIVT) { korreksjon.utbetalKorreksjon("", "X123456", "9999") }
-        assertFeilkode(Feilkode.KORREKSJONSBELOP_POSITIVT) { korreksjon.fullførKorreksjonVedTilbakekreving("") }
-        korreksjon.fullførKorreksjonVedOppgjort("")
+        korreksjon.oppgiBedriftKontonummer(innloggetBeslutter, "99999999999")
+        assertFeilkode(Feilkode.KORREKSJONSBELOP_NEGATIVT) { korreksjon.utbetalKorreksjon(innloggetBeslutter, "9999") }
+        assertFeilkode(Feilkode.KORREKSJONSBELOP_POSITIVT) {
+            korreksjon.fullførKorreksjonVedTilbakekreving(
+                innloggetBeslutter
+            )
+        }
+        korreksjon.fullførKorreksjonVedOppgjort(innloggetBeslutter)
         assertThat(korreksjon.status).isEqualTo(Korreksjonstype.OPPGJORT)
     }
 
@@ -208,8 +222,8 @@ class KorreksjonTest {
             inntektslinjeIkkeOptjentIPeriode
         )
         val inntektsgrunnlag = Inntektsgrunnlag(inntekter, "")
-        korreksjon.oppgiBedriftKontonummer("123456789")
-        korreksjon.oppgiInntektsgrunnlag(inntektsgrunnlag)
+        korreksjon.oppgiBedriftKontonummer(innloggetBeslutter, "123456789")
+        korreksjon.oppgiInntektsgrunnlag(innloggetBeslutter, inntektsgrunnlag)
 
         assertThat(korreksjon.refusjonsgrunnlag.beregning?.lønn).isEqualTo(inntektslinjeOpptjentIPeriode.beløp.toInt())
     }


### PR DESCRIPTION
Hendelseslogg-modal for saksbehandler i refusjonsside
[https://github.com/navikt/tiltak-refusjon-saksbehandler/pull/61](https://github.com/navikt/tiltak-refusjon-saksbehandler/pull/61)

- [x] vise status penere enn bare teksten fra databasen
- [x] fikse css så knappen ikke er gjenomsiktlig men vit
- [x] Vise ident for beslutter
- [x] Vise rolle for arbeidsgiver istedet for fnr

* Laget hendelsesloggmodal som lagrer hendelser for refusjonen og rollen som utført
* Refaktorert utførtAv så det er en interface av innloggetBruker