### PR TITLE
Secondary sort på refusjonsid

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
@@ -56,7 +56,7 @@ data class InnloggetArbeidsgiver(
     private fun getQueryMethodForFinnAlleForGittArbeidsgiver(bedriftNr: List<String>, status: RefusjonStatus?, tiltakstype: Tiltakstype?, sortingOrder: SortingOrder?, page: Int, size: Int): Page<Refusjon> {
         val paging: Pageable = PageRequest.of(page, size)
         if(sortingOrder != null && sortingOrder != SortingOrder.STATUS_ASC) {
-            return refusjonRepository.findAllByBedriftNrAndStatusDefinedSort(bedriftNr, status, tiltakstype, PageRequest.of(page, size, Sort.by(getSortingOrderForPageable(sortingOrder))))
+            return refusjonRepository.findAllByBedriftNrAndStatusDefinedSort(bedriftNr, status, tiltakstype, PageRequest.of(page, size, Sort.by(getSortingOrderForPageable(sortingOrder), Sort.Order.asc("id"))))
         }
         return refusjonRepository.findAllByBedriftNrAndStatusDefaultSort(bedriftNr, status, tiltakstype, paging)
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -29,7 +29,7 @@ data class InnloggetSaksbehandler(
     override val rolle: BrukerRolle = BrukerRolle.BESLUTTER
 
     fun finnAlle(queryParametre: HentSaksbehandlerRefusjonerQueryParametre): Map<String, Any> {
-        val pageable: Pageable = PageRequest.of(queryParametre.page, queryParametre.size, Sort.Direction.ASC, "fristForGodkjenning")
+        val pageable: Pageable = PageRequest.of(queryParametre.page, queryParametre.size, Sort.Direction.ASC, "fristForGodkjenning", "status", "id")
 
         val statuser = if (queryParametre.status != null) listOf(queryParametre.status) else RefusjonStatus.values().toList()
         val tiltakstyper = if (queryParametre.tiltakstype != null) listOf(queryParametre.tiltakstype) else Tiltakstype.values().toList()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonRepository.kt
@@ -57,7 +57,7 @@ interface RefusjonRepository : JpaRepository<Refusjon, String> {
     @Query("select r from Refusjon r where r.bedriftNr in (:bedriftNr) and (:status is null or r.status = :status) " +
             "and (:tiltakstype is null or r.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype = :tiltakstype) " +
             "order by (CASE WHEN r.status = 'KLAR_FOR_INNSENDING' THEN 0 else 1 END)," +
-            "r.refusjonsgrunnlag.tilskuddsgrunnlag.deltakerFornavn")
+            "r.refusjonsgrunnlag.tilskuddsgrunnlag.deltakerFornavn" +", r.id")
     fun findAllByBedriftNrAndStatusDefaultSort(
         @Param("bedriftNr") bedriftNr: List<String>,
         @Param("status") status: RefusjonStatus?,


### PR DESCRIPTION
Sortering på refusjonsoversikten for arbeidsgiver:
Sorterer på refusjon.id som secondary sort uansett hvilken primary sort man har, dermed vil alltid rekkefølgen bli lik selvom det er like verdier i primary sort.

TODO: fikse for veileder også.