### PR TITLE
Hendelselogg henter alle hendelser på refusjonsId

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelsesloggRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelsesloggRepository.kt
@@ -4,5 +4,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface HendelsesloggRepository : JpaRepository<Hendelseslogg, String>{
     fun findAllByRefusjonId(refusjonId: String): List<Hendelseslogg>
-    fun findAllBy
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelsesloggRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelsesloggRepository.kt
@@ -2,4 +2,7 @@ package no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface HendelsesloggRepository : JpaRepository<Hendelseslogg, String>
+interface HendelsesloggRepository : JpaRepository<Hendelseslogg, String>{
+    fun findAllByRefusjonId(refusjonId: String): List<Hendelseslogg>
+    fun findAllBy
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
@@ -45,8 +45,8 @@ class SaksbehandlerRefusjonController(
 
     @GetMapping("/{id}/hendelselogg")
     fun hentHendelselogg(@PathVariable id: String): List<HendelsesloggDTO> {
-        val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler().finnRefusjon(id)
-        val hendelser = hendelsesloggRepository.findAll().filter { it.refusjonId == saksbehandler.id }
+        val refusjon = innloggetBrukerService.hentInnloggetSaksbehandler().finnRefusjon(id)
+        val hendelser = hendelsesloggRepository.findAllByRefusjonId(refusjon.id)
         return hendelser.map { HendelsesloggDTO(it) }
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
@@ -6,7 +6,6 @@ import no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg.HendelsesloggDTO
 import no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg.HendelsesloggRepository
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.ForlengFristRequest
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.web.bind.annotation.*
 
 const val REQUEST_MAPPING_SAKSBEHANDLER_REFUSJON = "/api/saksbehandler/refusjon"


### PR DESCRIPTION
Istedet for å hente alle hendelser og etterpå filtrere på refusjonsId i backend så gjør vi filtreringen i database istedet. 