### PR TITLE
CookieTokenFilter for lokal utvikling

### DIFF
--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/CookieTokenFilter.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/CookieTokenFilter.kt
@@ -1,0 +1,49 @@
+package no.nav.arbeidsgiver.tiltakrefusjon
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequestWrapper
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * Dette filteret gjør at lokalkjøring av applikasjonen fortsatt fungerer med cookie-baserte
+ * jwt-tokens. Frontendene har en lokal login-mekanisme når man kjører i dev-modus som henter
+ * et fake JWT access-token og legger det i en cookie.
+ *
+ * Tidligere ble denne cookien plukket opp av token-validation-biblioteket, men siden versjon 4
+ * har støtte for cookies blitt fjernet.
+ *
+ * Ved å sørge for at dette filteret kjører før TokenValidationFilter sniker vi inn en auth-header
+ * som deretter plukkes opp av token-validering senere.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class CookieTokenFilter: OncePerRequestFilter() {
+    override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
+        val aadToken = request.cookies.find { it.name == "aad-token" }?.value
+        val tokenxToken = request.cookies.find { it.name == "tokenx-token" }?.value
+
+        if (request.requestURI.startsWith("/api/arbeidsgiver") && tokenxToken != null) {
+            val wrappedRequest = RequestMedToken(request, tokenxToken)
+            filterChain.doFilter(wrappedRequest, response)
+        } else if (request.requestURI.startsWith("/api/saksbehandler") && aadToken != null) {
+            val wrappedRequest = RequestMedToken(request, aadToken)
+            filterChain.doFilter(wrappedRequest, response)
+        } else {
+            filterChain.doFilter(request, response);
+        }
+    }
+}
+
+private class RequestMedToken(request: HttpServletRequest, val token: String): HttpServletRequestWrapper(request) {
+    override fun getHeader(name: String?): String? {
+        if (name?.lowercase() == "authorization") {
+            return "Bearer $token"
+        }
+        return super.getHeader(name)
+    }
+}

--- a/src/test/resources/application-dockercompose.yml
+++ b/src/test/resources/application-dockercompose.yml
@@ -17,6 +17,9 @@ spring:
   datasource:
     url: "jdbc:postgresql://localhost:7432/sample?user=sample&password=sample"
 no.nav.security.jwt:
+  tokenvalidationfilter:
+    # Gå vekk fra "highest presedence" slik at CookieTokenFilter får kjøre først
+    order: -10000
   issuer:
     aad:
       discoveryurl: https://tiltak-fakelogin.ekstern.dev.nav.no/metadata?issuer=aad

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -34,6 +34,9 @@ management:
     enabled: false
 
 no.nav.security.jwt:
+  tokenvalidationfilter:
+    # Gå vekk fra "highest presedence" slik at CookieTokenFilter får kjøre først
+    order: -10000
   issuer:
     aad:
       discoveryurl: https://tiltak-fakelogin.ekstern.dev.nav.no/metadata?issuer=aad


### PR DESCRIPTION
Siste oppgradering av token-validation-spring (v4) fjernet støtte for tokens som ligger i en cookie.
Det var vår måte å "logge inn" på i lokal utvikling.

Ved å redusere "presedensen" til valideringsfilteret og sette inn et "CookieTokenFilter" foran, kan vi
manuelt sette inn et token i auth-header som fanges opp av valideringsfilteret senere.