### PR TITLE
Rigge for migrering av abac til poao-tilgang

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetBrukerService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetBrukerService.kt
@@ -5,27 +5,31 @@ import no.nav.arbeidsgiver.tiltakrefusjon.altinn.AltinnTilgangsstyringService
 import no.nav.arbeidsgiver.tiltakrefusjon.inntekt.InntektskomponentService
 import no.nav.arbeidsgiver.tiltakrefusjon.norg.NorgService
 import no.nav.arbeidsgiver.tiltakrefusjon.okonomi.KontoregisterService
-import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.*
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Fnr
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.KorreksjonRepository
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.RefusjonRepository
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.RefusjonService
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Issuer
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.getClaims
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import java.util.*
 
 @Observed
 @Component
 class InnloggetBrukerService(
     val context: TokenValidationContextHolder,
     val altinnTilgangsstyringService: AltinnTilgangsstyringService,
-    val abacTilgangsstyringService: AbacTilgangsstyringService,
+    val tilgangskontrollService: TilgangskontrollService,
     val refusjonRepository: RefusjonRepository,
     val korreksjonRepository: KorreksjonRepository,
     val refusjonService: RefusjonService,
     val inntektskomponentService: InntektskomponentService,
     val kontoregisterService: KontoregisterService,
     val norgService: NorgService,
-    val beslutterRolleConfig: BeslutterRolleConfig
+    val beslutterRolleConfig: BeslutterRolleConfig,
 ) {
     var logger: Logger = LoggerFactory.getLogger(javaClass)
 
@@ -47,7 +51,13 @@ class InnloggetBrukerService(
     }
 
     fun navIdent(): String {
-        return context.getClaims(Issuer.AZURE)?.getStringClaim("NAVident") ?: throw IllegalArgumentException("Forsøker å hente navident for bruker som ikke er NAV-ansatt")
+        return context.getClaims(Issuer.AZURE)?.getStringClaim("NAVident")
+            ?: throw IllegalArgumentException("Forsøker å hente navident for bruker som ikke er NAV-ansatt")
+    }
+
+    fun azureOid(): UUID {
+        return context.getClaims(Issuer.AZURE)?.getStringClaim("oid")?.let { UUID.fromString(it) }
+            ?: throw IllegalArgumentException("Forsøker å hente azure oid for bruker som ikke er NAV-ansatt")
     }
 
     fun displayName(): String {
@@ -61,7 +71,10 @@ class InnloggetBrukerService(
     fun hentInnloggetArbeidsgiver(): InnloggetArbeidsgiver {
         return when {
             erArbeidsgiver() -> {
-                val fnr = Fnr(context.getClaims(Issuer.TOKEN_X)?.getStringClaim("pid") ?: throw IllegalArgumentException("Forsøker å hente pid for bruker som ikke er arbeidsgiver"))
+                val fnr = Fnr(
+                    context.getClaims(Issuer.TOKEN_X)?.getStringClaim("pid")
+                        ?: throw IllegalArgumentException("Forsøker å hente pid for bruker som ikke er arbeidsgiver")
+                )
                 InnloggetArbeidsgiver(fnr.verdi, altinnTilgangsstyringService, refusjonRepository, korreksjonRepository, refusjonService)
             }
 
@@ -77,7 +90,8 @@ class InnloggetBrukerService(
                 InnloggetSaksbehandler(
                     identifikator = navIdent(),
                     navn = displayName(),
-                    abacTilgangsstyringService = abacTilgangsstyringService,
+                    azureOid = azureOid(),
+                    tilgangskontrollService = tilgangskontrollService,
                     refusjonRepository = refusjonRepository,
                     korreksjonRepository = korreksjonRepository,
                     refusjonService = refusjonService,

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InternIdentifikatorer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InternIdentifikatorer.kt
@@ -1,0 +1,8 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.autorisering
+
+import java.util.*
+
+data class InternIdentifikatorer(
+    val navIdent: String,
+    val azureOid: UUID
+)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/TilgangskontrollService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/TilgangskontrollService.kt
@@ -1,0 +1,12 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.autorisering
+
+import org.springframework.stereotype.Service
+
+@Service
+class TilgangskontrollService(
+    val abacTilgangsstyringService: AbacTilgangsstyringService
+) {
+    fun harLeseTilgang(internIdentifikatorer: InternIdentifikatorer, deltakerFnr: String): Boolean {
+        return abacTilgangsstyringService.harLeseTilgang(internIdentifikatorer.navIdent, deltakerFnr)
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonApiTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonApiTest.kt
@@ -70,7 +70,7 @@ class RefusjonApiTest(
     @SpykBean
     lateinit var consoleLogger: AuditConsoleLogger
 
-    val navToken = lagTokenForNavId("Z123456")
+    val navToken = lagTokenForNavId("Z123456", "550e8400-e29b-41d4-a716-446655440000")
     val arbGiverToken = lagTokenForFnr("16120102137")
 
     @BeforeEach
@@ -369,11 +369,11 @@ class RefusjonApiTest(
         ).body()
     }
 
-    private final fun lagTokenForNavId(navId: String): String {
+    private final fun lagTokenForNavId(navId: String, azureId: String): String {
         return HttpClient.newHttpClient().send(
             HttpRequest.newBuilder()
                 .GET()
-                .uri(URI.create("https://tiltak-fakelogin.ekstern.dev.nav.no/token?NAVident=${navId}&iss=aad&aud=aud-aad"))
+                .uri(URI.create("https://tiltak-fakelogin.ekstern.dev.nav.no/token?NAVident=${navId}&iss=aad&aud=aud-aad&oid=${azureId}"))
                 .build(), BodyHandlers.ofString()
         ).body()
     }


### PR DESCRIPTION
Opprett et abstraksjonslag for tilgang som også legger til rette for bruk av azure-id (som er brukt i poao-tilgang)