### PR TITLE
Index på refusjonsgrunnlag->beregning

### DIFF
--- a/src/main/resources/db/migration/V55__indeks_refusjonsgrunnlag.sql
+++ b/src/main/resources/db/migration/V55__indeks_refusjonsgrunnlag.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS refusjonsgrunnlag_beregning_id_idx ON refusjonsgrunnlag (beregning_id);
+CREATE INDEX IF NOT EXISTS varsling_refusjon_id_idx ON varsling (refusjon_id);
+CREATE INDEX IF NOT EXISTS tilskuddsgrunnlag_tilskuddperiode_id_idx ON tilskuddsgrunnlag (tilskuddsperiode_id);


### PR DESCRIPTION
Analyse i prod viser at oppslag på refusjoner og
korreksjoner fører til en "seq scan" i beregning-
tabellen på 80000 rader ved hvert oppslag.