### PR TITLE
Legg til indeks i hendelseslogg

### DIFF
--- a/src/main/resources/db/migration/V56__indeks_hendelseslogg.sql
+++ b/src/main/resources/db/migration/V56__indeks_hendelseslogg.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS hendelseslogg_refusjon_id ON hendelseslogg (refusjon_id);


### PR DESCRIPTION
Vi gjør ofte oppslag på refusjon_id, som
ikke er en indeks.