### PR TITLE
Legg til beslutter ad-gruppe i labs

### DIFF
--- a/src/main/resources/application-dev-gcp-labs.yml
+++ b/src/main/resources/application-dev-gcp-labs.yml
@@ -45,3 +45,5 @@ tiltak-refusjon:
     mock: true
   norg:
     fake: true
+  beslutter-ad-gruppe:
+    id: BESLUTTER_AD_GRUPPE


### PR DESCRIPTION
Ved innlogging i labs kaster backenden feil grunnet
manglende verdi for dette feltet. Så vi kan løse det
ved å fylle inn en dummy-verdi.