### PR TITLE
Sett tidssone på godkjent_av_arbeidsgiver

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/Hendelseslogg.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/Hendelseslogg.kt
@@ -1,12 +1,16 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg
 
-import jakarta.persistence.*
+import jakarta.persistence.Convert
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BrukerRolle
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.ulid
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
-import java.time.LocalDateTime
+import java.time.Instant
 
 @Entity
 data class Hendelseslogg(
@@ -23,5 +27,5 @@ data class Hendelseslogg(
 ) {
     @Id
     val id: String = ulid()
-    val tidspunkt: LocalDateTime = Now.localDateTime()
+    val tidspunkt: Instant = Now.instant()
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelsesloggDTO.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/hendelseslogg/HendelsesloggDTO.kt
@@ -2,7 +2,7 @@ package no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg
 
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BrukerRolle
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.erGyldigFnr
-import java.time.LocalDateTime
+import java.time.Instant
 
 data class HendelsesloggDTO(
     val refusjonId: String,
@@ -10,7 +10,7 @@ data class HendelsesloggDTO(
     val utførtAv: String,
     val event: String,
     val metadata: HendelseMetadata? = null,
-    val tidspunkt: LocalDateTime,
+    val tidspunkt: Instant,
 ) {
     constructor(hendelseslogg: Hendelseslogg) : this(
         refusjonId = hendelseslogg.refusjonId,

--- a/src/main/resources/application-dev-gcp-labs.yml
+++ b/src/main/resources/application-dev-gcp-labs.yml
@@ -46,4 +46,4 @@ tiltak-refusjon:
   norg:
     fake: true
   beslutter-ad-gruppe:
-    id: BESLUTTER_AD_GRUPPE
+    id: 1a1d2745-952f-4a0f-839f-9530145b1d4a

--- a/src/main/resources/db/migration/V58__tidssone_for_godkjent_av_arbeidsgiver.sql
+++ b/src/main/resources/db/migration/V58__tidssone_for_godkjent_av_arbeidsgiver.sql
@@ -1,0 +1,4 @@
+-- godkjent_av_arbeidsgiver-feltet har ikke tidssone i databasen, men er en instant i jpa-entiteten.
+-- Instants er tidspunkter med tidssoner, så kolonnen burde også ha tidssone.
+alter table refusjon alter column godkjent_av_arbeidsgiver type timestamp with time zone
+    using godkjent_av_arbeidsgiver at time zone 'UTC';

--- a/src/main/resources/db/migration/V59__tidssone_for_utbetalt_tidspunkt.sql
+++ b/src/main/resources/db/migration/V59__tidssone_for_utbetalt_tidspunkt.sql
@@ -1,0 +1,4 @@
+-- godkjent_av_arbeidsgiver-feltet har ikke tidssone i databasen, men er en instant i jpa-entiteten.
+-- Instants er tidspunkter med tidssoner, så kolonnen burde også ha tidssone.
+alter table refusjon alter column utbetalt_tidspunkt type timestamp with time zone
+    using utbetalt_tidspunkt at time zone 'UTC';

--- a/src/main/resources/db/migration/V60__tidssone_for_hendelselogg_tidspunkt.sql
+++ b/src/main/resources/db/migration/V60__tidssone_for_hendelselogg_tidspunkt.sql
@@ -1,0 +1,5 @@
+-- tidspunkt-feltet har ikke tidssone i databasen, og er en "localdatetime" i jpa-entiteten.
+-- For å få tidspunktene til å bli riktige MED tidssone må vi derfor bruke "at time zone" med
+-- europe/oslo i stedet for utc, slik vi gjorde med feltene hvor jpa-entiteten bruker instant.
+alter table hendelseslogg alter column tidspunkt type timestamp with time zone
+    using tidspunkt at time zone 'Europe/Oslo';

--- a/src/test/resources/application-dockercompose.yml
+++ b/src/test/resources/application-dockercompose.yml
@@ -60,6 +60,8 @@ tiltak-refusjon:
     fake: true
   varsling:
     varsling-klar-cron: "0 */5 0 17 * ?"
+  beslutter-ad-gruppe:
+    id: 1a1d2745-952f-4a0f-839f-9530145b1d4a
 server:
   port: 8081
 


### PR DESCRIPTION
Databasekolonnen har ikke tidssone, men er mappet
til en instant i kodebasen (som har tidssone).

Denne migreringen setter tidssone på kolonnen slik at det ikke vil være forvirring (det er lett å tro at man ser på "norsk tid" i en spørring, når man
egentlig må legge på 2 timer for å se riktig tidspunkt)