### PR TITLE
Fiks for VTAO og inntektslinjer

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
@@ -81,7 +81,7 @@ class Korreksjon(
     var besluttetTidspunkt: Instant? = null
 
     @JsonProperty
-    fun harTattStillingTilAlleInntektslinjer(): Boolean = refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }?.find { inntekt -> inntekt.erOpptjentIPeriode === null } === null
+    fun harTattStillingTilAlleInntektslinjer(): Boolean = if (refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype == Tiltakstype.VTAO) true else (refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }?.find { inntekt -> inntekt.erOpptjentIPeriode === null } === null)
 
     override fun getFnrOgBedrift(): FnrOgBedrift = FnrOgBedrift(deltakerFnr, bedriftNr)
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
@@ -81,7 +81,13 @@ class Korreksjon(
     var besluttetTidspunkt: Instant? = null
 
     @JsonProperty
-    fun harTattStillingTilAlleInntektslinjer(): Boolean = if (refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype == Tiltakstype.VTAO) true else (refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }?.find { inntekt -> inntekt.erOpptjentIPeriode === null } === null)
+    fun harTattStillingTilAlleInntektslinjer(): Boolean =
+        refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }
+            ?.find { inntekt -> inntekt.erOpptjentIPeriode == null } == null
+
+    @JsonProperty
+    fun måTaStillingTilInntekter(): Boolean =
+        refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype != Tiltakstype.VTAO
 
     override fun getFnrOgBedrift(): FnrOgBedrift = FnrOgBedrift(deltakerFnr, bedriftNr)
 
@@ -130,7 +136,7 @@ class Korreksjon(
         if (kostnadssted.isBlank()) {
             throw FeilkodeException(Feilkode.KOSTNADSSTED_MANGLER)
         }
-        if (!this.harTattStillingTilAlleInntektslinjer()) {
+        if (this.måTaStillingTilInntekter() && !this.harTattStillingTilAlleInntektslinjer()) {
             throw FeilkodeException(Feilkode.IKKE_TATT_STILLING_TIL_ALLE_INNTEKTSLINJER)
         }
 
@@ -150,7 +156,7 @@ class Korreksjon(
         if (refusjonsbeløp == null || refusjonsbeløp != 0) {
             throw FeilkodeException(Feilkode.KORREKSJONSBELOP_IKKE_NULL)
         }
-        if (!this.harTattStillingTilAlleInntektslinjer()) {
+        if (this.måTaStillingTilInntekter() && !this.harTattStillingTilAlleInntektslinjer()) {
             throw FeilkodeException(Feilkode.IKKE_TATT_STILLING_TIL_ALLE_INNTEKTSLINJER)
         }
         this.godkjentTidspunkt = Now.instant()
@@ -166,7 +172,7 @@ class Korreksjon(
         if (refusjonsbeløp == null || refusjonsbeløp >= 0) {
             throw FeilkodeException(Feilkode.KORREKSJONSBELOP_POSITIVT)
         }
-        if (!this.harTattStillingTilAlleInntektslinjer()) {
+        if (this.måTaStillingTilInntekter() && !this.harTattStillingTilAlleInntektslinjer()) {
             throw FeilkodeException(Feilkode.IKKE_TATT_STILLING_TIL_ALLE_INNTEKTSLINJER)
         }
         this.godkjentTidspunkt = Now.instant()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -82,7 +82,13 @@ class Refusjon(
     }
 
     @JsonProperty
-    fun harTattStillingTilAlleInntektslinjer(): Boolean = if (refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype == Tiltakstype.VTAO) true else (refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }?.find { inntekt -> inntekt.erOpptjentIPeriode === null } === null)
+    fun harTattStillingTilAlleInntektslinjer(): Boolean =
+        refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }
+            ?.find { inntekt -> inntekt.erOpptjentIPeriode == null } == null
+
+    @JsonProperty
+    fun måTaStillingTilInntekter(): Boolean =
+        refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype != Tiltakstype.VTAO
 
     private fun krevStatus(vararg gyldigeStatuser: RefusjonStatus) {
         if (status !in gyldigeStatuser) throw FeilkodeException(Feilkode.UGYLDIG_STATUS)
@@ -159,7 +165,7 @@ class Refusjon(
         if (refusjonsgrunnlag.bedriftKontonummer == null) {
             throw FeilkodeException(Feilkode.INGEN_BEDRIFTKONTONUMMER)
         }
-        if (!this.harTattStillingTilAlleInntektslinjer()) {
+        if (this.måTaStillingTilInntekter() && !this.harTattStillingTilAlleInntektslinjer()) {
             throw FeilkodeException(Feilkode.IKKE_TATT_STILLING_TIL_ALLE_INNTEKTSLINJER)
         }
         if (refusjonsgrunnlag.beregning == null) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -82,10 +82,7 @@ class Refusjon(
     }
 
     @JsonProperty
-    fun harTattStillingTilAlleInntektslinjer(): Boolean {
-        val harTattStilling = refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }?.find { inntekt -> inntekt.erOpptjentIPeriode == null }
-        return harTattStilling == null
-    }
+    fun harTattStillingTilAlleInntektslinjer(): Boolean = if (refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype == Tiltakstype.VTAO) true else (refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }?.find { inntekt -> inntekt.erOpptjentIPeriode === null } === null)
 
     private fun krevStatus(vararg gyldigeStatuser: RefusjonStatus) {
         if (status !in gyldigeStatuser) throw FeilkodeException(Feilkode.UGYLDIG_STATUS)

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
@@ -816,7 +816,7 @@ fun `Vidar SendKrav`(): Refusjon {
     refusjon.let {
         it.medBedriftKontonummer()
         it.status = RefusjonStatus.SENDT_KRAV
-        it.godkjentAvArbeidsgiver = Now.instant().atZone(ZoneId.of("Europe/Oslo")).minusDays(5).toInstant()
+        it.godkjentAvArbeidsgiver = Now.localDate().minusMonths(1).with(lastDayOfMonth()).plusDays(1).atStartOfDay(ZoneId.of("Europe/Oslo")).toInstant()
     }
 
     return refusjon
@@ -842,8 +842,8 @@ fun `Vidar Utbetalt`(): Refusjon {
     refusjon.let {
         it.medBedriftKontonummer()
         it.status = RefusjonStatus.UTBETALT
-        it.godkjentAvArbeidsgiver = Now.instant().atZone(ZoneId.of("Europe/Oslo")).minusDays(5).toInstant()
-        it.utbetaltTidspunkt = Now.instant().atZone(ZoneId.of("Europe/Oslo")).minusDays(2).toInstant()
+        it.godkjentAvArbeidsgiver = Now.localDate().minusMonths(1).with(lastDayOfMonth()).plusDays(1).atStartOfDay(ZoneId.of("Europe/Oslo")).toInstant()
+        it.utbetaltTidspunkt = Now.localDate().minusMonths(1).with(lastDayOfMonth()).plusDays(3).atStartOfDay(ZoneId.of("Europe/Oslo")).toInstant()
     }
 
     return refusjon

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
@@ -1,15 +1,23 @@
 package no.nav.arbeidsgiver.tiltakrefusjon
 
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
-import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.*
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BrukerRolle
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Inntektsgrunnlag
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Inntektslinje
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.RefusjonStatus
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Tilskuddsgrunnlag
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Tiltakstype
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.beregnRefusjonsbeløp
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.ulid
 import no.nav.arbeidsgiver.tiltakrefusjon.varsling.VarselType
 import no.nav.arbeidsgiver.tiltakrefusjon.varsling.Varsling
 import java.time.YearMonth
 import java.time.ZoneId
+import java.time.temporal.TemporalAdjusters.firstDayOfMonth
 import java.time.temporal.TemporalAdjusters.lastDayOfMonth
-import java.util.UUID
+import java.util.*
 
 val innloggetTestbruker = innloggetBruker("testsystem", BrukerRolle.SYSTEM)
 
@@ -816,7 +824,10 @@ fun `Vidar SendKrav`(): Refusjon {
     refusjon.let {
         it.medBedriftKontonummer()
         it.status = RefusjonStatus.SENDT_KRAV
-        it.godkjentAvArbeidsgiver = Now.localDate().minusMonths(1).with(lastDayOfMonth()).plusDays(1).atStartOfDay(ZoneId.of("Europe/Oslo")).toInstant()
+        it.godkjentAvArbeidsgiver = Now.localDate()
+            .with(firstDayOfMonth())
+            .atStartOfDay(ZoneId.of("Europe/Oslo"))
+            .toInstant()
     }
 
     return refusjon
@@ -842,8 +853,15 @@ fun `Vidar Utbetalt`(): Refusjon {
     refusjon.let {
         it.medBedriftKontonummer()
         it.status = RefusjonStatus.UTBETALT
-        it.godkjentAvArbeidsgiver = Now.localDate().minusMonths(1).with(lastDayOfMonth()).plusDays(1).atStartOfDay(ZoneId.of("Europe/Oslo")).toInstant()
-        it.utbetaltTidspunkt = Now.localDate().minusMonths(1).with(lastDayOfMonth()).plusDays(3).atStartOfDay(ZoneId.of("Europe/Oslo")).toInstant()
+        it.godkjentAvArbeidsgiver = Now.localDate()
+            .with(firstDayOfMonth())
+            .atStartOfDay(ZoneId.of("Europe/Oslo"))
+            .toInstant()
+        it.utbetaltTidspunkt = Now.localDate()
+            .with(firstDayOfMonth())
+            .plusDays(2)
+            .atStartOfDay(ZoneId.of("Europe/Oslo"))
+            .toInstant()
     }
 
     return refusjon

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
@@ -449,6 +449,9 @@ fun refusjoner(): List<Refusjon> {
         `Amalie Skram`(),
         `Suzanna Hansen`(),
         `Siri Hansen`(),
+        `Vidar Fortidlig`(),
+        `Vidar SendKrav`(),
+        `Vidar Utbetalt`(),
         `Camilla Collett`(),
         `Snorre Sturlason`(),
         `Sigrid Undset`(),
@@ -762,6 +765,76 @@ fun `Siri Hansen`(): Refusjon {
         it.medBeregning()
         it.medSendtKravFraArbeidsgiver()
         it.utbetalingMislykket()
+    }
+
+    return refusjon
+}
+
+fun `Vidar Fortidlig`(): Refusjon {
+    val deltakerFnr = "23119409195"
+    val bedriftNr = "999999999"
+    val refusjon = Refusjon(
+        tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(
+            tiltakstype = Tiltakstype.VTAO,
+            deltakerFornavn = "Vidar",
+            deltakerEtternavn = "Olsen",
+            deltakerFnr = deltakerFnr,
+            bedriftNr = bedriftNr,
+            tilskuddsbeløp = 6808,
+            veilederNavIdent = "X123456"
+        ), bedriftNr = bedriftNr, deltakerFnr = deltakerFnr,
+    )
+
+    refusjon.let {
+        it.medBedriftKontonummer()
+        it.status = RefusjonStatus.FOR_TIDLIG
+    }
+
+    return refusjon
+}
+
+fun `Vidar SendKrav`(): Refusjon {
+    val deltakerFnr = "23119409195"
+    val bedriftNr = "999999999"
+    val refusjon = Refusjon(
+        tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(
+            tiltakstype = Tiltakstype.VTAO,
+            deltakerFornavn = "Vidar",
+            deltakerEtternavn = "Olsen",
+            deltakerFnr = deltakerFnr,
+            bedriftNr = bedriftNr,
+            tilskuddsbeløp = 6808,
+            veilederNavIdent = "X123456"
+        ), bedriftNr = bedriftNr, deltakerFnr = deltakerFnr
+    )
+
+    refusjon.let {
+        it.medBedriftKontonummer()
+        it.status = RefusjonStatus.SENDT_KRAV
+    }
+
+    return refusjon
+}
+
+fun `Vidar Utbetalt`(): Refusjon {
+    val deltakerFnr = "23119409195"
+    val bedriftNr = "999999999"
+    val refusjon = Refusjon(
+        tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(
+            tiltakstype = Tiltakstype.VTAO,
+            deltakerFornavn = "Vidar",
+            deltakerEtternavn = "Olsen",
+            deltakerFnr = deltakerFnr,
+            bedriftNr = bedriftNr,
+            tilskuddsbeløp = 6808,
+            veilederNavIdent = "X123456"
+        ), bedriftNr = bedriftNr, deltakerFnr = deltakerFnr
+    )
+
+    refusjon.let {
+        it.medBedriftKontonummer()
+        it.status = RefusjonStatus.UTBETALT
+
     }
 
     return refusjon

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
@@ -784,6 +784,9 @@ fun `Vidar Fortidlig`(): Refusjon {
     val bedriftNr = "999999999"
     val refusjon = Refusjon(
         tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(
+            avtaleId = UUID.randomUUID().toString(),
+            avtaleNr = 4414,
+            tilskuddsperiodeId = UUID.randomUUID().toString(),
             tiltakstype = Tiltakstype.VTAO,
             deltakerFornavn = "Vidar",
             deltakerEtternavn = "Olsen",
@@ -809,6 +812,9 @@ fun `Vidar SendKrav`(): Refusjon {
     val bedriftNr = "999999999"
     val refusjon = Refusjon(
         tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(
+            avtaleId = UUID.randomUUID().toString(),
+            avtaleNr = 4414,
+            tilskuddsperiodeId = UUID.randomUUID().toString(),
             tiltakstype = Tiltakstype.VTAO,
             deltakerFornavn = "Vidar",
             deltakerEtternavn = "Olsen",
@@ -838,6 +844,9 @@ fun `Vidar Utbetalt`(): Refusjon {
     val bedriftNr = "999999999"
     val refusjon = Refusjon(
         tilskuddsgrunnlag = etTilskuddsgrunnlag().copy(
+            avtaleId = UUID.randomUUID().toString(),
+            avtaleNr = 4414,
+            tilskuddsperiodeId = UUID.randomUUID().toString(),
             tiltakstype = Tiltakstype.VTAO,
             deltakerFornavn = "Vidar",
             deltakerEtternavn = "Olsen",

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
@@ -7,6 +7,7 @@ import no.nav.arbeidsgiver.tiltakrefusjon.utils.ulid
 import no.nav.arbeidsgiver.tiltakrefusjon.varsling.VarselType
 import no.nav.arbeidsgiver.tiltakrefusjon.varsling.Varsling
 import java.time.YearMonth
+import java.time.ZoneId
 import java.time.temporal.TemporalAdjusters.lastDayOfMonth
 import java.util.UUID
 
@@ -781,7 +782,9 @@ fun `Vidar Fortidlig`(): Refusjon {
             deltakerFnr = deltakerFnr,
             bedriftNr = bedriftNr,
             tilskuddsbeløp = 6808,
-            veilederNavIdent = "X123456"
+            veilederNavIdent = "X123456",
+            avtaleFom = Now.localDate().minusMonths(3).withDayOfMonth(1),
+            avtaleTom = Now.localDate().plusYears(2).withDayOfMonth(1),
         ), bedriftNr = bedriftNr, deltakerFnr = deltakerFnr,
     )
 
@@ -804,13 +807,16 @@ fun `Vidar SendKrav`(): Refusjon {
             deltakerFnr = deltakerFnr,
             bedriftNr = bedriftNr,
             tilskuddsbeløp = 6808,
-            veilederNavIdent = "X123456"
+            veilederNavIdent = "X123456",
+            avtaleFom = Now.localDate().minusMonths(3).withDayOfMonth(1),
+            avtaleTom = Now.localDate().plusYears(2).withDayOfMonth(1),
         ), bedriftNr = bedriftNr, deltakerFnr = deltakerFnr
     )
 
     refusjon.let {
         it.medBedriftKontonummer()
         it.status = RefusjonStatus.SENDT_KRAV
+        it.godkjentAvArbeidsgiver = Now.instant().atZone(ZoneId.of("Europe/Oslo")).minusDays(5).toInstant()
     }
 
     return refusjon
@@ -827,14 +833,17 @@ fun `Vidar Utbetalt`(): Refusjon {
             deltakerFnr = deltakerFnr,
             bedriftNr = bedriftNr,
             tilskuddsbeløp = 6808,
-            veilederNavIdent = "X123456"
+            veilederNavIdent = "X123456",
+            avtaleFom = Now.localDate().minusMonths(3).withDayOfMonth(1),
+            avtaleTom = Now.localDate().plusYears(2).withDayOfMonth(1),
         ), bedriftNr = bedriftNr, deltakerFnr = deltakerFnr
     )
 
     refusjon.let {
         it.medBedriftKontonummer()
         it.status = RefusjonStatus.UTBETALT
-
+        it.godkjentAvArbeidsgiver = Now.instant().atZone(ZoneId.of("Europe/Oslo")).minusDays(5).toInstant()
+        it.utbetaltTidspunkt = Now.instant().atZone(ZoneId.of("Europe/Oslo")).minusDays(2).toInstant()
     }
 
     return refusjon


### PR DESCRIPTION
For å unngå feilmelding når en VTAO-avtale godkjennes,
må vi gjøre en endring i backend som sjekker om man faktisk
må ta stilling til inntekter før man sjekker om det er blitt tatt
stilling til.

Foreløpig er det bare for VTAO-avtaler at man ikke må ta stilling
til inntekter, så sjekken er foreløpig ganske enkel.

Setter også opp litt VTAO-testdata