### PR TITLE
Flytt avhengighet til test-scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-contract-stub-runner</artifactId>
             <version>4.1.1</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Denne endringen fjerner rundt 50-60 mb med
avhengigheter fra jar-pakken.

Jar-størrelse før endring: 145M
Jar-størrelse etter endring: 87M

Reduserer også antall sårbarheter:
![image](https://github.com/user-attachments/assets/9317fc0e-cd82-453b-8b13-52eddb884185)
