### PR TITLE
Nytt api-endepunkt: maks godkjenningsfrist

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -38,7 +38,7 @@ class Refusjon(
     val id: String = ulid()
 
     // Fristen er satt til 2 mnd ihht reimplementation. Hvis etterregistrert 2 mnd etter godkjent tidspunkt av beslutter
-    var fristForGodkjenning: LocalDate = lagFristForGodkjenning()
+    var fristForGodkjenning: LocalDate = lagOpprinneligFristForGodkjenning()
 
     var forrigeFristForGodkjenning: LocalDate? = null
 
@@ -70,10 +70,7 @@ class Refusjon(
         registerEvent(RefusjonOpprettet(this, SYSTEM_BRUKER))
     }
 
-    fun lagFristForGodkjenning(): LocalDate {
-        if (refusjonsgrunnlag.tilskuddsgrunnlag.godkjentAvBeslutterTidspunkt == null) {
-            return antallMånederEtter(refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom, 2)
-        }
+    fun lagOpprinneligFristForGodkjenning(): LocalDate {
         if (refusjonsgrunnlag.tilskuddsgrunnlag.godkjentAvBeslutterTidspunkt.toLocalDate().isAfter(refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom)) {
             return antallMånederEtter(refusjonsgrunnlag.tilskuddsgrunnlag.godkjentAvBeslutterTidspunkt.toLocalDate(), 2)
         } else {
@@ -292,7 +289,7 @@ class Refusjon(
     }
 
     fun maksForlengeFrist(): LocalDate {
-        val opprinneligFrist = lagFristForGodkjenning()
+        val opprinneligFrist = lagOpprinneligFristForGodkjenning()
         return if (refusjonsgrunnlag.fratrekkRefunderbarBeløp == true) antallMånederEtter(
             refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom,
             13

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
@@ -8,6 +8,7 @@ import no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg.HendelsesloggRepository
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.ForlengFristRequest
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
 
 const val REQUEST_MAPPING_SAKSBEHANDLER_REFUSJON = "/api/saksbehandler/refusjon"
 
@@ -76,5 +77,15 @@ class SaksbehandlerRefusjonController(
     fun reberegnDryRun(@PathVariable id: String, @RequestBody request: ReberegnRequest): Beregning {
         val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler()
         return saksbehandler.reberegnDryRun(id, request.harFerietrekkForSammeMåned, request.minusBeløp)
+    }
+
+    @GetMapping("/{id}/hent-min-og-maks-godkjenningsfrist")
+    fun hentMinOgMaksGodkjenningsfrist(@PathVariable id: String): Map<String, LocalDate> {
+        val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler()
+        val refusjon = saksbehandler.finnRefusjon(id)
+        return mapOf(
+            "minDato" to refusjon.fristForGodkjenning,
+            "maksDato" to refusjon.maksForlengeFrist()
+        )
     }
 }


### PR DESCRIPTION
For at frontend skal kunne vite hva som er maks
godkjenningsfrist, opprettes et nytt endepunkt
som gjengir logikken til backend.