### PR TITLE
Ikke auditlogg listeoppslag

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverRefusjonController.kt
@@ -45,7 +45,6 @@ class ArbeidsgiverRefusjonController(
 ) {
     var logger: Logger = LoggerFactory.getLogger(javaClass)
 
-    @AuditLogging("Oversikt over refusjoner")
     @GetMapping
     fun hentAlle(queryParametre: HentArbeidsgiverRefusjonerQueryParametre): List<Refusjon> {
         if (queryParametre.bedriftNr == null) {
@@ -72,7 +71,6 @@ class ArbeidsgiverRefusjonController(
 
     }
 
-    @AuditLogging("Oversikt over refusjoner")
     @GetMapping("/hentliste")
     fun hentListAvBedrifter(queryParametre: HentArbeidsgiverRefusjonerQueryParametre): ResponseEntity<Map<String, Any>> {
         val arbeidsgiver = innloggetBrukerService.hentInnloggetArbeidsgiver()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/SaksbehandlerRefusjonController.kt
@@ -33,7 +33,6 @@ class SaksbehandlerRefusjonController(
     val innloggetBrukerService: InnloggetBrukerService,
     val hendelsesloggRepository: HendelsesloggRepository,
 ) {
-    @AuditLogging("Oversiktsbilde over refusjoner")
     @GetMapping
     fun hentAlle(queryParametre: HentSaksbehandlerRefusjonerQueryParametre): Map<String, Any> {
         val saksbehandler = innloggetBrukerService.hentInnloggetSaksbehandler()

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonApiTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonApiTest.kt
@@ -134,11 +134,6 @@ class RefusjonApiTest(
         // DA
         assertTrue(liste.all { it.bedriftNr == bedriftNr })
         assertEquals(4, liste.size)
-
-        // Forventer at oppslag auditlogges, men kun én gang per unike deltaker
-        verify(exactly = liste.map { it.deltakerFnr }.toSet().size) {
-            consoleLogger.logg(any())
-        }
     }
 
 
@@ -154,23 +149,12 @@ class RefusjonApiTest(
         val refusjonJson =
             sendRequest(get("$REQUEST_MAPPING_ARBEIDSGIVER_REFUSJON/hentliste?page=0&size=3"), arbGiverToken)
         val refusjonlist: RefusjonlistFraFlereOrgTest = mapper.readValue(refusjonJson, object : TypeReference<RefusjonlistFraFlereOrgTest>() {})
-        verify(exactly = refusjonlist.refusjoner.map { mapOf("deltaker" to it.deltakerFnr, "bedrift" to it.bedriftNr) }.toSet().size) {
-            consoleLogger.logg(any())
-        }
-        resetAuditCount()
         val refusjonJson2 =
             sendRequest(get("$REQUEST_MAPPING_ARBEIDSGIVER_REFUSJON/hentliste?page=1&size=3"), arbGiverToken)
         val refusjonlist2: RefusjonlistFraFlereOrgTest = mapper.readValue(refusjonJson2, object : TypeReference<RefusjonlistFraFlereOrgTest>() {})
-        verify(exactly = refusjonlist2.refusjoner.map { mapOf("deltaker" to it.deltakerFnr, "bedrift" to it.bedriftNr) }.toSet().size) {
-            consoleLogger.logg(any())
-        }
-        resetAuditCount()
         val refusjonJson3 =
             sendRequest(get("$REQUEST_MAPPING_ARBEIDSGIVER_REFUSJON/hentliste?page=0&size=6"), arbGiverToken)
         val refusjonlist3: RefusjonlistFraFlereOrgTest = mapper.readValue(refusjonJson3, object : TypeReference<RefusjonlistFraFlereOrgTest>() {})
-        verify(exactly = refusjonlist3.refusjoner.map { mapOf("deltaker" to it.deltakerFnr, "bedrift" to it.bedriftNr) }.toSet().size) {
-            consoleLogger.logg(any())
-        }
 
         // SÅ
         assertThat(refusjonlist.refusjoner).allMatch { bedrifter -> bruker.organisasjoner.any { it.organizationNumber == bedrifter.bedriftNr } }


### PR DESCRIPTION
Dersom informasjonen til en deltaker dukker opp
i en listevisning, skal ikke dette medføre logging til arcsight.

Formålet med auditlogging er å logge oppslag på en spesifikk bruker, men listeoppslagene vil skape
unødvendig støy.

Dette er beskrevet i etterlevelseskrav K253.1