### PR TITLE
Inkluder "id" i auditlogging

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/audit/AuditElement.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/audit/AuditElement.kt
@@ -1,0 +1,16 @@
+package no.nav.arbeidsgiver.tiltakrefusjon.audit
+
+data class AuditElement(
+    val id: String,
+    val deltakerFnr: String,
+    val bedrift: String
+) {
+    companion object {
+        fun of(it: AuditerbarEntitet) = AuditElement(
+            it.id,
+            it.getFnrOgBedrift().deltakerFnr,
+            it.getFnrOgBedrift().bedrift
+        )
+    }
+
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/audit/AuditerbarEntitet.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/audit/AuditerbarEntitet.kt
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.audit
 
-interface RefusjonMedFnrOgBedrift {
+interface AuditerbarEntitet {
+    val id: String
     fun getFnrOgBedrift(): FnrOgBedrift
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
@@ -12,7 +12,7 @@ import jakarta.persistence.OneToOne
 import no.nav.arbeidsgiver.tiltakrefusjon.Feilkode
 import no.nav.arbeidsgiver.tiltakrefusjon.FeilkodeException
 import no.nav.arbeidsgiver.tiltakrefusjon.audit.FnrOgBedrift
-import no.nav.arbeidsgiver.tiltakrefusjon.audit.RefusjonMedFnrOgBedrift
+import no.nav.arbeidsgiver.tiltakrefusjon.audit.AuditerbarEntitet
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.KorreksjonMerketForOppgjort
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.KorreksjonMerketForTilbakekreving
@@ -33,7 +33,7 @@ class Korreksjon(
     val bedriftNr: String,
     val unntakOmInntekterFremitid: Int?,
     val annenGrunn: String?
-) : AbstractAggregateRoot<Korreksjon>(), RefusjonMedFnrOgBedrift {
+) : AbstractAggregateRoot<Korreksjon>(), AuditerbarEntitet {
     constructor(
         korrigererRefusjonId: String,
         korreksjonsnummer: Int,
@@ -64,7 +64,7 @@ class Korreksjon(
     }
 
     @Id
-    val id: String = ulid()
+    override val id: String = ulid()
 
     @Enumerated(EnumType.STRING)
     @ElementCollection(fetch = FetchType.EAGER)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -1,14 +1,30 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import jakarta.persistence.*
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.OneToOne
 import no.nav.arbeidsgiver.tiltakrefusjon.Feilkode
 import no.nav.arbeidsgiver.tiltakrefusjon.FeilkodeException
+import no.nav.arbeidsgiver.tiltakrefusjon.audit.AuditerbarEntitet
 import no.nav.arbeidsgiver.tiltakrefusjon.audit.FnrOgBedrift
-import no.nav.arbeidsgiver.tiltakrefusjon.audit.RefusjonMedFnrOgBedrift
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.SYSTEM_BRUKER
-import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.*
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.FristForlenget
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.GodkjentAvArbeidsgiver
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.KryssetAvForFravær
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.MerketForInntekterFrem
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.RefusjonAnnullert
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.RefusjonEndretStatus
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.RefusjonForkortet
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.RefusjonGodkjentMinusBeløp
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.RefusjonGodkjentNullBeløp
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.RefusjonOpprettet
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.RefusjonUtgått
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.events.SaksbehandlerMerketForInntekterLengerFrem
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.MidlerFrigjortÅrsak
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.KidValidator
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
@@ -25,7 +41,7 @@ class Refusjon(
     val refusjonsgrunnlag: Refusjonsgrunnlag,
     val bedriftNr: String,
     val deltakerFnr: String
-) : AbstractAggregateRoot<Refusjon>(), RefusjonMedFnrOgBedrift {
+) : AbstractAggregateRoot<Refusjon>(), AuditerbarEntitet {
     constructor(
         tilskuddsgrunnlag: Tilskuddsgrunnlag,
         bedriftNr: String,
@@ -35,7 +51,7 @@ class Refusjon(
     )
 
     @Id
-    val id: String = ulid()
+    override val id: String = ulid()
 
     // Fristen er satt til 2 mnd ihht reimplementation. Hvis etterregistrert 2 mnd etter godkjent tidspunkt av beslutter
     var fristForGodkjenning: LocalDate = finnTidligsteFristForGodkjenning()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/AuditEntry.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/events/AuditEntry.kt
@@ -7,6 +7,7 @@ data class AuditEntry(
     val appNavn: String,
     val utførtAv: String, // Nav-ident eller fnr på arbeidsgiver
     val oppslagPå: String, // Fnr på person det gjøres oppslag på, eller organisasjon
+    val entitetId: String,
     val eventType: EventType,
     val forespørselTillatt: Boolean,
     val oppslagUtførtTid: Instant,


### PR DESCRIPTION
Formålet med endringen er å kunne spore unike oppslag på en deltaker sin informasjon.

Hvorfor behøver vi den informasjonen? Fordi auditlogging av oppslag skal kun skje dersom en avtale ikke har endret seg! Men det medfører at auditlogging-appen vår vet at et oppslag er unikt.