### PR TITLE
Fiks "race condtion" for etterregistret VTAO

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -80,10 +80,6 @@ class RefusjonService(
 
         oppdaterRefusjon(refusjon, SYSTEM_BRUKER)
 
-        if (tilskuddsgrunnlag.tiltakstype.utbetalesAutomatisk() && refusjon.status == RefusjonStatus.KLAR_FOR_INNSENDING) {
-            this.utførAutomatiskInnsendingHvisMulig(refusjon)
-        }
-
         return refusjonRepository.save(refusjon)
     }
 
@@ -361,9 +357,8 @@ class RefusjonService(
     }
 
     fun utførAutomatiskInnsendingHvisMulig(refusjon: Refusjon) {
-        val refusjonensTiltaktstype = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype
-        if (!refusjonensTiltaktstype.utbetalesAutomatisk()) {
-            throw IllegalStateException("Refusjon ${refusjon.id} kan ikke sendes inn automatisk (tiltakstype ${refusjonensTiltaktstype})")
+        if (!refusjon.tiltakstype().utbetalesAutomatisk()) {
+            throw IllegalStateException("Refusjon ${refusjon.id} kan ikke sendes inn automatisk (tiltakstype ${refusjon.tiltakstype()})")
         }
         log.info(
             "Utfører automatisk innsending av refusjon {}-{} ({})",

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
@@ -510,7 +510,7 @@ class RefusjonServiceTest(
     }
 
     @Test
-    fun `godkjenner etterregistrert VTAO tilskuddsperiode gir refusjon med status sendt`() {
+    fun `godkjenner etterregistrert VTAO tilskuddsperiode gir refusjon med status for tidlig`() {
         val deltakerFnr = "00000000000"
         val tilskuddMelding = TilskuddsperiodeGodkjentMelding(
             avtaleId = "1",
@@ -543,7 +543,7 @@ class RefusjonServiceTest(
 
         val lagretRefusjon = refusjonRepository.findByIdOrNull(refusjon.id)
         if (lagretRefusjon != null) {
-            assertThat(lagretRefusjon.status).isEqualTo(RefusjonStatus.SENDT_KRAV)
+            assertThat(lagretRefusjon.status).isEqualTo(RefusjonStatus.FOR_TIDLIG)
         }
     }
 


### PR DESCRIPTION
Etterregistrerte vtao-avtaler skal automatisk utsendes. Men når vi mottar en slik refusjon burde vi ikke sende den til økonomiløsningen umiddelbart, da dette kan føre til at faktura blir forsøkt opprettet før ordre! Da vil fakturaen feile i økonomi.

Denne endringen vil føre til at etterregistrerte VTAO-refusjoner vil være merket "for tidlig" i én dag, før de sendes inn automatisk på natten.