### PR TITLE
Fiks labs - wiremock deployer ikke

### DIFF
--- a/.github/workflows/bygg-og-deploy-labs.yml
+++ b/.github/workflows/bygg-og-deploy-labs.yml
@@ -1,10 +1,11 @@
-name: Bygg og deploy
+name: Bygg og deploy - Labs
 
 on:
-  push:
-    branches:
-      - 'master'
   workflow_dispatch:
+  schedule:
+    # Kjør litt tidligere enn tiltaksgjennomforing slik at avtaleløsning
+    # kan pushe refusjoner til refusjonsløsning
+    - cron: '45 4 * * 1-5'
 
 jobs:
   build:
@@ -37,10 +38,50 @@ jobs:
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
 
-  deploy-dev:
-    name: Deploy til dev
+  build-push-wiremock-image:
     runs-on: ubuntu-latest
-    needs: build
+    name: 'Bygg og push Wiremock-image'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Sjekk ut kode
+        uses: actions/checkout@v4
+
+      - name: Push Docker Image to GAR
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          image_suffix: wiremock
+          team: arbeidsgiver
+          dockerfile: DockerfileWiremock
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+
+  deploy-wiremock:
+    needs: build-push-wiremock-image
+    name: 'Deploy Wiremock to dev-gcp'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Sjekk ut kode
+        uses: actions/checkout@v4
+
+      - name: Deploy til gcp
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLUSTER: dev-gcp
+          TEAM: arbeidsgiver
+          RESOURCE: ".nais/wiremock.yml"
+          VAR: image=${{ needs.build-push-wiremock-image.outputs.image }}
+
+  deploy-dev-gcp-labs:
+    name: Deploy til dev-gcp (tidligere labs)
+    runs-on: ubuntu-latest
+    needs: [ build, deploy-wiremock ]
     permissions:
       contents: read
       id-token: write
@@ -52,26 +93,5 @@ jobs:
         uses: nais/deploy/actions/deploy@v2
         env:
           CLUSTER: dev-gcp
-          RESOURCE: .nais/nais.yml,.nais/alertsNy.yml,.nais/alertsTesting.yml,.nais/unleash-apitoken.yml
-          VARS: .nais/dev.yml
-          VAR: image=${{ needs.build.outputs.image }}
-
-  deploy-prod:
-    name: Deploy til prod
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-      id-token: write
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Sjekk ut kode
-        uses: actions/checkout@v4
-
-      - name: Deploy til prod-gcp
-        uses: nais/deploy/actions/deploy@v2
-        env:
-          CLUSTER: prod-gcp
-          RESOURCE: .nais/nais.yml,.nais/alertsNy.yml,.nais/unleash-apitoken.yml
-          VARS: .nais/prod.yml
+          RESOURCE: .nais/dev-gcp-labs.yml
           VAR: image=${{ needs.build.outputs.image }}

--- a/.github/workflows/bygg-og-deploy.yml
+++ b/.github/workflows/bygg-og-deploy.yml
@@ -76,10 +76,9 @@ jobs:
           VARS: .nais/prod.yml
           VAR: image=${{ needs.build.outputs.image }}
 
-  deploy-dev-gcp-labs:
-    name: Deploy til dev-gcp (tidligere labs)
+  build-push-wiremock-image:
     runs-on: ubuntu-latest
-    needs: build
+    name: 'Bygg og push Wiremock-image'
     permissions:
       contents: read
       id-token: write
@@ -87,16 +86,50 @@ jobs:
       - name: Sjekk ut kode
         uses: actions/checkout@v4
 
-      - name: Generer tiltak-refusjon-api-wiremock configmap
-        run: |
-          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x ./kubectl
-          ./kubectl create configmap --dry-run=client -o yaml --from-file src/test/resources/mappings -n arbeidsgiver tiltak-refusjon-api-wiremock > .nais/wiremock-mappings.yml
-          cat .nais/wiremock-mappings.yml # debug
+      - name: Push Docker Image to GAR
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          image_suffix: wiremock
+          team: arbeidsgiver
+          dockerfile: DockerfileWiremock
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+
+  deploy-wiremock:
+    needs: build-push-wiremock-image
+    name: 'Deploy Wiremock to dev-gcp'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Sjekk ut kode
+        uses: actions/checkout@v4
+
+      - name: Deploy til gcp
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLUSTER: dev-gcp
+          TEAM: arbeidsgiver
+          RESOURCE: ".nais/wiremock.yml"
+          VAR: image=${{ needs.build-push-wiremock-image.outputs.image }}
+
+  deploy-dev-gcp-labs:
+    name: Deploy til dev-gcp (tidligere labs)
+    runs-on: ubuntu-latest
+    needs: [ build, deploy-wiremock ]
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Sjekk ut kode
+        uses: actions/checkout@v4
 
       - name: Deploy til dev-gcp
         uses: nais/deploy/actions/deploy@v2
         env:
           CLUSTER: dev-gcp
-          RESOURCE: .nais/dev-gcp-labs.yml,.nais/wiremock.yml,.nais/wiremock-mappings.yml
-          VAR: deploytrigger=${{ github.run_number }},image=${{ needs.build.outputs.image }}
+          RESOURCE: .nais/dev-gcp-labs.yml
+          VAR: image=${{ needs.build.outputs.image }}

--- a/.nais/wiremock.yml
+++ b/.nais/wiremock.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: arbeidsgiver
 spec:
-  image: docker.pkg.github.com/navikt/tiltak-refusjon-api/tiltak-refusjon-wiremock:2.27.2
+  image: {{image}}
   replicas:
     min: 1
     max: 1
@@ -30,12 +30,6 @@ spec:
     requests:
       cpu: 500m
       memory: 500Mi
-  env:
-  - name: deploytrigger
-    value: "{{deploytrigger}}"
-  filesFrom:
-  - configmap: tiltak-refusjon-api-wiremock
-    mountPath: /home/wiremock/mappings
   accessPolicy:
     inbound:
       rules:

--- a/DockerfileWiremock
+++ b/DockerfileWiremock
@@ -1,0 +1,10 @@
+# Use the official WireMock image as the base
+FROM wiremock/wiremock:3.12.1-alpine
+
+# Expose the default WireMock port
+EXPOSE 8080
+
+COPY src/test/resources/mappings/ /home/wiremock/mappings/
+
+# Default command to start WireMock
+CMD ["--verbose"]


### PR DESCRIPTION
En endring i Nais-plattformen gjorde at wiremock-imaget vårt ikke deployer lenger.

Denne endringen gjør at vi deployer wiremock på en litt mindre magisk måte, i tillegg til en fungerende måte.