### PR TITLE
Fiks warning om "maks uri-tags" i metrikker

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/norg/NorgServiceImp.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/norg/NorgServiceImp.kt
@@ -1,12 +1,11 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.norg
 
-import no.nav.arbeidsgiver.tiltakrefusjon.utils.ConditionalOnPropertyNotEmpty
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Service
-import org.springframework.web.client.RestTemplate
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
 
 @Service
 @Profile("dev-gcp", "prod-gcp")
@@ -14,10 +13,14 @@ class NorgServiceImp(@Qualifier("anonymProxyRestTemplate") val restTemplate: Res
     val log: Logger = LoggerFactory.getLogger(javaClass)
 
     override fun hentEnhetNavn(enhet: String): String? {
-        val uri = properties.uri + "/enhet/" + enhet
+        val uri = properties.uri + "/enhet/{enhet}"
         try {
-            val norgResponse = restTemplate.getForEntity(uri, NorgEnhetResponse::class.java)
-            return norgResponse.body?.navn ?: null
+            val norgResponse = restTemplate.getForEntity(
+                uri,
+                NorgEnhetResponse::class.java,
+                mapOf("enhet" to enhet)
+            )
+            return norgResponse.body?.navn
         } catch (e: Exception) {
             log.error("Kall mot Norg feilet", e)
             return null

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/okonomi/KontoregisterServiceImpl.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/okonomi/KontoregisterServiceImpl.kt
@@ -28,10 +28,15 @@ class KontoregisterServiceImpl(
     val log: Logger = LoggerFactory.getLogger(javaClass)
     override fun hentBankkontonummer(bedriftNr: String): String? {
         val requestEntity = lagRequest()
-        val url = "${properties.uri}/${bedriftNr}"
+        val url = "${properties.uri}/{bedriftNr}"
         try {
             val responseMedKontonummerTilBedrift =
-                restTemplate.exchange<KontoregisterResponse>(url, HttpMethod.GET, requestEntity).body
+                restTemplate.exchange<KontoregisterResponse>(
+                    url,
+                    HttpMethod.GET,
+                    requestEntity,
+                    mapOf("bedriftNr" to bedriftNr)
+                ).body
             return responseMedKontonummerTilBedrift?.kontonr
         } catch (e: RestClientException) {
             log.warn("Kontoregister kall feiler", e)


### PR DESCRIPTION
Vi får en advarsel om at http-klienten produserer metrikker med for mange unike tags. Det betyr kort og godt at vi lager metrikker med metadata som feks:

`http_client_requests_active_seconds_sum{...,uri="/kontoregister/api/v1/hent-kontonummer-for-organisasjon/123456789"} 0.0`

i stedet for:

`http_client_requests_active_seconds_sum{...,uri="/kontoregister/api/v1/hent-kontonummer-for-organisasjon/{bedriftNr}"} 0.0`

Merk endringen på slutten av URL'en, hvor vi frem til nå har logget bedriftnummeret i stedet for en 'variabel'.

Løsningen på dette er å sende inn uri-variabler ("{bedriftNr}") i en egen hashmap. Vi slipper da også å potensielt logge fødselsnumre i prometheus-metrikkene våre.