### PR TITLE
Beregning påstår at beregnet beløp "utgår"

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
@@ -1,7 +1,7 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
-import no.nav.arbeidsgiver.tiltakrefusjon.utils.gjenståendeEtterMaks5G
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.erMånedIPeriode
+import no.nav.arbeidsgiver.tiltakrefusjon.utils.gjenståendeEtterMaks5G
 import java.time.LocalDate
 import kotlin.math.roundToInt
 
@@ -92,13 +92,15 @@ fun beregnRefusjonsbeløp(
         beregnetBeløp = beregnetBeløpUtenFratrukketRefundertBeløp
     }
 
-    val overTilskuddsbeløp = beregnetBeløp > tilskuddsgrunnlag.tilskuddsbeløp
-    var refusjonsbeløp =
-        (if (overTilskuddsbeløp) tilskuddsgrunnlag.tilskuddsbeløp.toDouble() else beregnetBeløp) - tidligereUtbetalt + forrigeRefusjonMinusBeløp
+    val avrundetBeregnetBeløp: Int = beregnetBeløp.roundToInt()
+
+    val overTilskuddsbeløp = avrundetBeregnetBeløp > tilskuddsgrunnlag.tilskuddsbeløp
+    var refusjonsbeløp: Int =
+        (if (overTilskuddsbeløp) tilskuddsgrunnlag.tilskuddsbeløp else avrundetBeregnetBeløp) - tidligereUtbetalt + forrigeRefusjonMinusBeløp
     var overFemGrunnbeløp = false
     if (tilskuddsgrunnlag.tiltakstype == Tiltakstype.VARIG_LONNSTILSKUDD) {
-        if (refusjonsbeløp > gjenståendeEtterMaks5G(sumUtbetaltVarig.toDouble(), tilskuddFom)) {
-            refusjonsbeløp = gjenståendeEtterMaks5G(sumUtbetaltVarig.toDouble(), tilskuddFom)
+        if (refusjonsbeløp > gjenståendeEtterMaks5G(sumUtbetaltVarig, tilskuddFom)) {
+            refusjonsbeløp = gjenståendeEtterMaks5G(sumUtbetaltVarig, tilskuddFom)
             overFemGrunnbeløp = true
         }
     }
@@ -110,8 +112,8 @@ fun beregnRefusjonsbeløp(
         tjenestepensjon = tjenestepensjon.roundToInt(),
         arbeidsgiveravgift = arbeidsgiveravgift.roundToInt(),
         sumUtgifter = sumUtgifter.roundToInt(),
-        beregnetBeløp = beregnetBeløp.roundToInt(),
-        refusjonsbeløp = refusjonsbeløp.roundToInt(),
+        beregnetBeløp = avrundetBeregnetBeløp,
+        refusjonsbeløp = refusjonsbeløp,
         overTilskuddsbeløp = overTilskuddsbeløp,
         tidligereUtbetalt = tidligereUtbetalt,
         fratrekkLønnFerie = trekkgrunnlagFerie,

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/utils/5GSjekkerUtil.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/utils/5GSjekkerUtil.kt
@@ -7,9 +7,9 @@ val forrigeÅretsG = 118620
 val datoForGJustering = LocalDate.of(2024, 5, 1)
 
 // Returnerer det man får opp til 5G. Altså 5G - Totalt utbetalt
-fun gjenståendeEtterMaks5G(sumUtbetalt: Double, tilskuddFom: LocalDate): Double {
-    if(tilskuddFom.plusDays(1).isBefore(datoForGJustering)) {
-        return 0.0.coerceAtLeast(5 * forrigeÅretsG - sumUtbetalt)
+fun gjenståendeEtterMaks5G(sumUtbetalt: Int, tilskuddFom: LocalDate): Int {
+    if (tilskuddFom.plusDays(1).isBefore(datoForGJustering)) {
+        return 0.coerceAtLeast(5 * forrigeÅretsG - sumUtbetalt)
     }
-    return 0.0.coerceAtLeast(5 * åretsG - sumUtbetalt)
+    return 0.coerceAtLeast(5 * åretsG - sumUtbetalt)
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonsberegnerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonsberegnerTest.kt
@@ -206,4 +206,34 @@ class RefusjonsberegnerTest {
         assertThat(beregning.sumUtgifter).isEqualTo(21375)
 
     }
+
+    @Test
+    fun `desimaler fører ikke til at beregning er overTilskuddsbeløp`(){
+        val tilskuddsgrunnlagLønnstilskudd = lagEtTilskuddsgrunnlag(
+            LocalDate.of(2023, 9, 1),
+            LocalDate.of(2023, 9, 30),
+            Tiltakstype.VARIG_LONNSTILSKUDD,
+            10000
+        )
+
+        val inntektslinje = lagEnInntektslinje(19493.00, YearMonth.of(2023, 9), LocalDate.of(2023, 9, 1), LocalDate.of(2023, 9, 30))
+
+        val beregning = beregnRefusjonsbeløp(
+            listOf(inntektslinje),
+            tilskuddsgrunnlagLønnstilskudd,
+            0,
+            null,
+            tilskuddFom = LocalDate.of(2023,9,1),
+            sumUtbetaltVarig = 16666,
+            harFerietrekkForSammeMåned = false
+        )
+
+        assertThat(beregning.refusjonsbeløp)
+            .isEqualTo(tilskuddsgrunnlagLønnstilskudd.tilskuddsbeløp)
+            .describedAs("Refusjonsbeløp og tilskuddsbeløp er like")
+        assertThat(beregning.overTilskuddsbeløp)
+            .isEqualTo(false)
+            .describedAs("Hvis beløpene er like, kan ikke overTilskuddsbeløp være sann. Vil isåfall bety at vi inkluderer desimaler i beregningen")
+
+    }
 }


### PR DESCRIPTION
I utregningen på en refusjon vil vi markere at beregnet beløp utgår dersom det er høyere enn tilskuddsbeløpet.

Problemet er at på tidspunktet vi sjekker om beløpet er over eller under tilskuddsbeløp så er beregnet beløp fortsatt en double! Senere så runder vi av til integer. Da kan vi ende opp med at beregnet beløp er 0.49 kroner over tilskuddsbeløp, men i utregningen ser det ut som begge beløp er identiske.

Vi løser dette ved å runde av til int FØR sjekkene på "over 5g" og "over tilskuddsbeløp".