### PR TITLE
Legg til logg-destinasjoner

### DIFF
--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -82,3 +82,8 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: team_logs
+        - id: loki


### PR DESCRIPTION
Vi ønsker å eksportere loggene våre til kibana
selv etter 1. juni!

Nais-plattformen har deprekert elasticsearch, og
derfor må vi eksplisitt legge til elastic til
listen over logg-destinasjoner i nais-yaml'en