### PR TITLE
Tiltakstype.kanIkkeOverskride5g

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
@@ -1,37 +1,8 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
-import no.nav.arbeidsgiver.tiltakrefusjon.utils.erMånedIPeriode
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.gjenståendeEtterMaks5G
 import java.time.LocalDate
 import kotlin.math.roundToInt
-
-private fun beløpPerInntektslinje(
-    inntektslinje: Inntektslinje,
-    fom: LocalDate,
-    tom: LocalDate,
-    tiltakstype: Tiltakstype,
-): Double {
-    if (inntektslinje.opptjeningsperiodeFom == null || inntektslinje.opptjeningsperiodeTom == null || tiltakstype == Tiltakstype.SOMMERJOBB)
-        return if (erMånedIPeriode(inntektslinje.måned, fom, tom)) {
-            inntektslinje.beløp
-        } else {
-            0.0
-        }
-
-    if (inntektslinje.opptjeningsperiodeTom < fom) {
-        return 0.0
-    }
-
-    val antallDagerSkalFordelesPå =
-        antallDager(inntektslinje.opptjeningsperiodeFom, inntektslinje.opptjeningsperiodeTom)
-    val dagsats = inntektslinje.beløp / antallDagerSkalFordelesPå
-
-
-    return dagsats * antallDager(
-        maxOf(fom, inntektslinje.opptjeningsperiodeFom),
-        minOf(tom, inntektslinje.opptjeningsperiodeTom)
-    )
-}
 
 private fun antallDager(
     fom: LocalDate,
@@ -131,7 +102,7 @@ fun beregnRefusjonsbeløp(
     var refusjonsbeløp: Int =
         (if (overTilskuddsbeløp) tilskuddsgrunnlag.tilskuddsbeløp else avrundetBeregnetBeløp) - tidligereUtbetalt + forrigeRefusjonMinusBeløp
     var overFemGrunnbeløp = false
-    if (tilskuddsgrunnlag.tiltakstype == Tiltakstype.VARIG_LONNSTILSKUDD) {
+    if (tilskuddsgrunnlag.tiltakstype.kanIkkeOverskride5g()) {
         if (refusjonsbeløp > gjenståendeEtterMaks5G(sumUtbetaltVarig, tilskuddFom)) {
             refusjonsbeløp = gjenståendeEtterMaks5G(sumUtbetaltVarig, tilskuddFom)
             overFemGrunnbeløp = true

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Tiltakstype.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Tiltakstype.kt
@@ -5,4 +5,8 @@ enum class Tiltakstype {
 
     fun utbetalesAutomatisk() = this == VTAO || this == MENTOR
     fun harFastUtbetalingssum() = this == VTAO || this == MENTOR
+    fun kanIkkeOverskride5g() = when (this) {
+        VARIG_LONNSTILSKUDD -> true
+        MIDLERTIDIG_LONNSTILSKUDD, SOMMERJOBB, VTAO, MENTOR -> false
+    }
 }


### PR DESCRIPTION
I stedet for å "iffe" på spesifikke tiltakstyper
rundt omkring i koden for å sjekke om vi skal
kontrollere for 5g, lager vi en funksjon
i Tiltakstype-enummen.