### PR TITLE
Fjern rester etter tiltak-proxy

### DIFF
--- a/.nais/dev.yml
+++ b/.nais/dev.yml
@@ -1,9 +1,6 @@
 host:
-  - tiltak-proxy.dev-fss-pub.nais.io
   - sokos-kontoregister-q2.dev-fss-pub.nais.io
   - g.nav.no
-  - graph.microsoft.com
-  - login.microsoftonline.com
   - team-tiltak-unleash-api.nav.cloud.nais.io
   - pdl-api.dev-fss-pub.nais.io
 tenant: trygdeetaten.no
@@ -13,7 +10,6 @@ strengt-fortrolig-adresse-gruppe: a1b518e2-3947-478d-8929-e5d685c47cac
 slack_alert_channel: arbeidsgiver-notifications-test
 kafka-pool: nav-dev
 env:
-  PROXY_CLIENT_ID: dev-fss.arbeidsgiver.tiltak-proxy
   MILJO: dev-gcp
 db-tier: db-f1-micro
 db-high-availability: false

--- a/.nais/prod.yml
+++ b/.nais/prod.yml
@@ -1,9 +1,6 @@
 host:
-  - tiltak-proxy.prod-fss-pub.nais.io
   - sokos-kontoregister.prod-fss-pub.nais.io
   - g.nav.no
-  - graph.microsoft.com
-  - login.microsoftonline.com
   - team-tiltak-unleash-api.nav.cloud.nais.io
   - pdl-api.prod-fss-pub.nais.io
 tenant: nav.no
@@ -13,7 +10,6 @@ strengt-fortrolig-adresse-gruppe: 2931da41-8b8e-42cd-99c0-04a169ddae40
 slack_alert_channel: arbeidsgiver-tiltak-alerts
 kafka-pool: nav-prod
 env:
-  PROXY_CLIENT_ID: prod-fss.arbeidsgiver.tiltak-proxy
   MILJO: prod-gcp
 db-tier: db-custom-2-7680
 db-high-availability: true

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/SecurityClientConfiguration.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/SecurityClientConfiguration.kt
@@ -32,9 +32,6 @@ class SecurityClientConfiguration(
     fun påVegneAvArbeidsgiverAltinn3RestTemplate() = restTemplateForRegistration("tokenx-altinn-3")
 
     @Bean
-    fun anonymProxyRestTemplate() = restTemplateForRegistration("aad-anonym")
-
-    @Bean
     fun sokosRestTemplate() = restTemplateForRegistration("sokos-kontoregister")
 
     @Bean

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/norg/NorgServiceImp.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/norg/NorgServiceImp.kt
@@ -2,22 +2,24 @@ package no.nav.arbeidsgiver.tiltakrefusjon.norg
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.client.getForEntity
 
 @Service
 @Profile("dev-gcp", "prod-gcp")
-class NorgServiceImp(@Qualifier("anonymProxyRestTemplate") val restTemplate: RestTemplate, val properties: NorgProperties) : NorgService {
+class NorgServiceImp(
+    private val noAuthRestTemplate: RestTemplate,
+    private val properties: NorgProperties
+) : NorgService {
     val log: Logger = LoggerFactory.getLogger(javaClass)
 
     override fun hentEnhetNavn(enhet: String): String? {
         val uri = properties.uri + "/enhet/{enhet}"
         try {
-            val norgResponse = restTemplate.getForEntity(
+            val norgResponse = noAuthRestTemplate.getForEntity<NorgEnhetResponse>(
                 uri,
-                NorgEnhetResponse::class.java,
                 mapOf("enhet" to enhet)
             )
             return norgResponse.body?.navn

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -70,14 +70,6 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      aad-anonym:
-        token-endpoint-url: https://login.microsoftonline.com/${AZURE_APP_TENANT_ID}/oauth2/v2.0/token
-        grant-type: client_credentials
-        scope: api://${PROXY_CLIENT_ID}/.default
-        authentication:
-          client-id: ${AZURE_APP_CLIENT_ID}
-          client-secret: ${AZURE_APP_CLIENT_SECRET}
-          client-auth-method: client_secret_basic
       pdl-api:
         token-endpoint-url: https://login.microsoftonline.com/${AZURE_APP_TENANT_ID}/oauth2/v2.0/token
         grant-type: client_credentials

--- a/src/main/resources/application-prod-gcp.yml
+++ b/src/main/resources/application-prod-gcp.yml
@@ -70,14 +70,6 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      aad-anonym:
-        token-endpoint-url: https://login.microsoftonline.com/${AZURE_APP_TENANT_ID}/oauth2/v2.0/token
-        grant-type: client_credentials
-        scope: api://${PROXY_CLIENT_ID}/.default
-        authentication:
-          client-id: ${AZURE_APP_CLIENT_ID}
-          client-secret: ${AZURE_APP_CLIENT_SECRET}
-          client-auth-method: client_secret_basic
       pdl-api:
         token-endpoint-url: https://login.microsoftonline.com/${AZURE_APP_TENANT_ID}/oauth2/v2.0/token
         grant-type: client_credentials


### PR DESCRIPTION
Vi bruker ikke lenger tiltak-proxy, og behøver derfor heller ikke å definere en kobling til proxy sin host-url.

Vi har heller ingen api-koblinger til microsoft sine api, dette ble gjort i en tid hvor vi trodde vi måtte bruke graph-apiet for å hente innlogget bruker sitt navn.

En morsom detalj er at når vi fjerner "api-scope" for tiltak-proxy så må vi fjerne en rest template som ble brukt i Norg2-kallene våre. Disse kallene utførte vi sannsynligvis via tiltak-proxy tidligere, og etter vi begynte å kalle Norg2 direkte så har de ignorert JWT-tokenet vi legger ved, som er for tiltak-proxy!

Det betyr at dersom vi hadde lagt ned tiltak-proxy først, så ville denne appen begynt å feile fordi den ikke får opprettet ubrukelige tokens.