### PR TITLE
Fjern håndlaget oppryddingskode for tabeller i tester

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -98,11 +98,10 @@ class RefusjonService(
     fun settMinusBeløpFraTidligereRefusjonerTilknyttetAvtalen(refusjon: Refusjon) {
         val avtaleNr = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr
         val alleMinusbeløp = minusbelopRepository.findAllByAvtaleNr(avtaleNr = avtaleNr)
-        if (!alleMinusbeløp.isNullOrEmpty()) {
+        if (alleMinusbeløp.isNotEmpty()) {
             val sumMinusbelop = alleMinusbeløp
                 .filter { !it.gjortOpp }
-                .map { minusbelop -> minusbelop.beløp }
-                .filterNotNull()
+                .mapNotNull { minusbelop -> minusbelop.beløp }
                 .reduceOrNull { sum, beløp -> sum + beløp }
             if (sumMinusbelop != null) {
                 refusjon.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(sumMinusbelop)
@@ -171,11 +170,12 @@ class RefusjonService(
     fun godkjennForArbeidsgiver(refusjon: Refusjon, utførtAv: InnloggetBruker) {
         val alleMinusBeløp = minusbelopRepository.findAllByAvtaleNr(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr)
         val sumMinusbelop = alleMinusBeløp
-            .filter { !it.gjortOpp }.mapNotNull { minusbelop -> minusbelop.beløp }
+            .filter { !it.gjortOpp }
+            .mapNotNull { minusbelop -> minusbelop.beløp }
             .reduceOrNull { sum, beløp -> sum + beløp }
         // Om det er et gammelt minusbeløp, men alle minusbeløp er gjort opp må refusjonen lastes på ny for å reberegnes
         if (sumMinusbelop != null && sumMinusbelop != 0 && refusjon.refusjonsgrunnlag.forrigeRefusjonMinusBeløp != sumMinusbelop) {
-            log.info("Arbeidsgiver prøver sende inn en refusjon hvor minusbeløp er gjort opp/endret av annen refusjon $refusjon.id")
+            log.info("Arbeidsgiver prøver å sende inn en refusjon hvor minusbeløp er gjort opp/endret av annen refusjon ${refusjon.id}")
             throw FeilkodeException(Feilkode.LAST_REFUSJONEN_PÅ_NYTT_REFUSJONSGRUNNLAG_ENDRET)
         }
         sjekkForTrukketFerietrekkForSammeMåned(refusjon)
@@ -189,6 +189,7 @@ class RefusjonService(
                 minusbelopRepository.save(it)
             }
         }
+
         // Lag en nytt minusbeløp om refusjonen er i minus
         if (refusjon.status == RefusjonStatus.GODKJENT_MINUSBELØP) {
             val minusbelop = Minusbelop(
@@ -199,8 +200,9 @@ class RefusjonService(
             refusjon.minusbelop = minusbelop
             log.info("Setter minusbeløp ${minusbelop.id} på refusjon ${refusjon.id}")
         }
+
         refusjonRepository.save(refusjon)
-        // Oppdater ikke innsendte refusjoner med data (f eks maksbløp, ferietrekk etc..)
+        // Oppdater åpne refusjoner med data (feks maksbeløp, sumUtbetalt for 5g-beregning, ferietrekk etc..)
         val alleRefusjonerSomSkalSendesInn =
             refusjonRepository.findAllByRefusjonsgrunnlag_Tilskuddsgrunnlag_AvtaleNrAndStatusIn(
                 refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr,

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonApiTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonApiTest.kt
@@ -15,15 +15,12 @@ import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.REQUEST_MAPPING_INNLOGGET
 import no.nav.arbeidsgiver.tiltakrefusjon.hendelseslogg.HendelsesloggRepository
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjoner
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
-import no.nav.arbeidsgiver.tiltakrefusjon.varsling.VarslingRepository
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -51,17 +48,13 @@ data class InnloggetBrukerTest(val identifikator: String, val organisasjoner: Se
 @ActiveProfiles("local")
 @AutoConfigureMockMvc
 @AutoConfigureWireMock
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@DirtiesContext
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class RefusjonApiTest(
     @param:Autowired val refusjonRepository: RefusjonRepository,
     @param:Autowired val refusjonService: RefusjonService,
     @param:Autowired val mapper: ObjectMapper,
     @param:Autowired val mockMvc: MockMvc,
     @param:Autowired val hendelsesloggRepository: HendelsesloggRepository,
-    @param:Autowired val fristForlengetRepository: FristForlengetRepository,
-    @param:Autowired val korreksjonRepository: KorreksjonRepository,
-    @param:Autowired val varslingRepository: VarslingRepository
 ) {
     @SpykBean
     lateinit var consoleLogger: AuditConsoleLogger
@@ -83,15 +76,6 @@ class RefusjonApiTest(
         every {
             consoleLogger.logg(any())
         } returns Unit
-    }
-
-    @AfterEach
-    fun tearDown() {
-        varslingRepository.deleteAll()
-        fristForlengetRepository.deleteAll()
-        hendelsesloggRepository.deleteAll()
-        korreksjonRepository.deleteAll()
-        refusjonRepository.deleteAll()
     }
 
     @Test
@@ -124,7 +108,6 @@ class RefusjonApiTest(
         // DA
         assertEquals(List(4) { bedriftNr }, bedriftNrListe)
     }
-
 
     @Test
     fun `hentAlle refusjon for alle bedrifter arbeidsgiver har tilgang til`() {

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
@@ -3,43 +3,33 @@ package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 import no.nav.arbeidsgiver.tiltakrefusjon.innloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeGodkjentMelding
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
-import no.nav.arbeidsgiver.tiltakrefusjon.varsling.VarslingRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.TemporalAdjusters.lastDayOfMonth
 
-private val åretsG = 124028
-private val forrigeÅretsG = 118620
+private const val åretsG = 124028
+private const val forrigeÅretsG = 118620
 
 @SpringBootTest(properties = ["NAIS_APP_IMAGE=test"])
 @ActiveProfiles("local")
 @AutoConfigureWireMock
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class RefusjonVarig5GTest(
-    @Autowired
-    val refusjonService: RefusjonService,
-    @Autowired
-    val refusjonRepository: RefusjonRepository,
-    @Autowired
-    val varslingRepository: VarslingRepository
+    @param:Autowired
+    private val refusjonService: RefusjonService,
+    @param:Autowired
+    private val refusjonRepository: RefusjonRepository,
 ) {
-    @BeforeEach
-    fun setup() {
-        varslingRepository.deleteAll()
-        refusjonRepository.deleteAll()
-    }
-
     @AfterEach
     fun teardown() {
-        varslingRepository.deleteAll()
-        refusjonRepository.deleteAll()
         Now.resetClock()
     }
 


### PR DESCRIPTION
I forbindelse arbeid med å få samkjørt kode som håndterer refusjoner og korreksjoner
ble det en del rotete opprydningskode i tester som bruker "deleteAll" for å fjerne refusjoner
og korreksjoner; man vil typisk treffe på en foreign key constraint ettersom refusjoner
har en referanse til korreksjoner.

For å slippe å styre med disse tingene kan vi sørge for at de ulike testene starter opp en
fersk H2-base hver gang.

Kanskje vi kan hoppe over til testcontainers senere...?