### PR TITLE
Utvid Beregningskontekst

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
@@ -186,7 +186,7 @@ class AdminController(
             harFerietrekkForSammeMåned = request.harFerietrekkForSammeMåned,
             sumUtbetaltVarig = refusjon.refusjonsgrunnlag.sumUtbetaltVarig,
             ekstraFerietrekk = request.ferieTrekk,
-            beregningskontekst = Beregningskontekst(grunnbelopService.alleGrunnbelop())
+            beregningskontekst = refusjonService.hentBeregningskontekst(refusjon)
         )
     }
 
@@ -205,7 +205,7 @@ class AdminController(
             harFerietrekkForSammeMåned = request.harFerietrekkForSammeMåned,
             sumUtbetaltVarig = refusjon.refusjonsgrunnlag.sumUtbetaltVarig,
             ekstraFerietrekk = request.ferieTrekk,
-            beregningskontekst = Beregningskontekst(grunnbelopService.alleGrunnbelop())
+            beregningskontekst = refusjonService.hentBeregningskontekst(refusjon)
         )
         refusjon.refusjonsgrunnlag.forrigeRefusjonMinusBeløp = request.minusBeløp
         refusjon.refusjonsgrunnlag.beregning = beregning

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/RequestDebugFilter.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/RequestDebugFilter.kt
@@ -14,8 +14,9 @@ import org.springframework.web.filter.OncePerRequestFilter
 class RequestDebugFilter: OncePerRequestFilter() {
     val log = LoggerFactory.getLogger(javaClass)
     override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
-        if (request.getHeader("if-unmodified-since") != null) {
-            log.info("if-unmodified-since fra header: ${request.getHeader("if-unmodified-since")}")
+        val ifUnmodifiedSince = request.getHeader("if-unmodified-since")
+        if (ifUnmodifiedSince != null && ifUnmodifiedSince != "") {
+            log.info("if-unmodified-since fra header: $ifUnmodifiedSince")
         }
         filterChain.doFilter(request, response)
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -9,7 +9,6 @@ import no.nav.arbeidsgiver.tiltakrefusjon.okonomi.KontoregisterService
 import no.nav.arbeidsgiver.tiltakrefusjon.persondata.PersondataService
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BegrensetRefusjon
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Beregning
-import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Beregningskontekst
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BrukerRolle
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.HentSaksbehandlerRefusjonerQueryParametre
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Inntektsgrunnlag
@@ -324,7 +323,7 @@ data class InnloggetSaksbehandler(
             tilskuddFom = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
             harFerietrekkForSammeMåned = harFerietrekkForSammeMåned,
             sumUtbetaltVarig = refusjon.refusjonsgrunnlag.sumUtbetaltVarig,
-            beregningskontekst = Beregningskontekst(grunnbelopService.alleGrunnbelop())
+            beregningskontekst = refusjonService.hentBeregningskontekst(refusjon)
         )
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverRefusjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/ArbeidsgiverRefusjonController.kt
@@ -103,7 +103,7 @@ class ArbeidsgiverRefusjonController(
     @Transactional
     fun settKontonummerOgInntekterPåRefusjon(@PathVariable id: String, @RequestHeader(HttpHeaders.IF_UNMODIFIED_SINCE) sistEndret: Instant?) {
         val arbeidsgiver = innloggetBrukerService.hentInnloggetArbeidsgiver()
-        arbeidsgiver.settKontonummerOgInntekterPåRefusjon(id, sistEndret);
+        arbeidsgiver.settKontonummerOgInntekterPåRefusjon(id, sistEndret)
     }
 
     @PostMapping("{id}/sett-kontonummer-og-inntekter", consumes = ["application/json"])

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Beregningskontekst.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Beregningskontekst.kt
@@ -6,7 +6,10 @@ import java.util.*
 
 class Beregningskontekst(
     private val alleGrunnbelop: TreeMap<LocalDate, Int>,
-    private val innsendteRefunderinger: Collection<Refundering>,
+    /**
+     * Skal gjøres private når vi migrerer vekk fra gammel 5g-beregning
+     */
+    public val innsendteRefunderinger: Collection<Refundering>,
     private val uoppgjorteMinusbelop: Collection<Minusbelop>
 ) {
     /**
@@ -23,6 +26,23 @@ class Beregningskontekst(
         val grunnbelopForPeriode = grunnbelopForPerioden(tilskuddFom)
         val gjenstående = 0.coerceAtLeast(5 * grunnbelopForPeriode.belop - sumUtbetaltSaaLangtIAaret)
         
+        return if (belopSomSkalUtbetales > gjenstående) {
+            Maks5GResultat.OverMaks(gjenstående)
+        } else {
+            Maks5GResultat.InnenforMaks()
+        }
+    }
+
+    /**
+     * Skal ta over for gammel beregningslogikk. Kjøres side om side midlertidig for å sammenligne resultater.
+     */
+    fun gjenståendeEtterMaks5GNy(tilskuddFom: LocalDate, belopSomSkalUtbetales: Int): Maks5GResultat {
+        val sumUtbetaltSaaLangtIAaret = this.innsendteRefunderinger
+            .mapNotNull { it.refusjonsgrunnlag.beregning?.refusjonsbeløp }
+            .sum()
+        val grunnbelopForPeriode = grunnbelopForPerioden(tilskuddFom)
+        val gjenstående = 0.coerceAtLeast(5 * grunnbelopForPeriode.belop - sumUtbetaltSaaLangtIAaret)
+
         return if (belopSomSkalUtbetales > gjenstående) {
             Maks5GResultat.OverMaks(gjenstående)
         } else {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Beregningskontekst.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Beregningskontekst.kt
@@ -5,7 +5,9 @@ import java.time.LocalDate
 import java.util.*
 
 class Beregningskontekst(
-    private val alleGrunnbelop: TreeMap<LocalDate, Int>
+    private val alleGrunnbelop: TreeMap<LocalDate, Int>,
+    private val innsendteRefunderinger: Collection<Refundering>,
+    private val uoppgjorteMinusbelop: Collection<Minusbelop>
 ) {
     /**
      * Hent grunnbeløpet som gjelder for en gitt dato.

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/KorreksjonRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/KorreksjonRepository.kt
@@ -1,6 +1,8 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
 
 interface KorreksjonRepository : JpaRepository<Korreksjon, String> {
 
@@ -9,5 +11,24 @@ interface KorreksjonRepository : JpaRepository<Korreksjon, String> {
         bedriftNr: String,
         status: List<Korreksjonstype>,
         tiltakstype: Tiltakstype
+    ): List<Korreksjon>
+
+    @Query(
+        """
+        select k from Korreksjon k
+        where k.deltakerFnr = :deltakerFnr and k.bedriftNr = :bedriftNr
+          and k.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype = :tiltakstype
+          and k.status in (:status)
+          and k.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom >= :periodeStart
+          and k.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom <= :periodeSlutt
+    """
+    )
+    fun hentDeltakersKorreksjoner(
+        deltakerFnr: String,
+        bedriftNr: String,
+        tiltakstype: Tiltakstype,
+        status: List<Korreksjonstype>,
+        periodeStart: LocalDate,
+        periodeSlutt: LocalDate
     ): List<Korreksjon>
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Maks5GResultat.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Maks5GResultat.kt
@@ -1,6 +1,18 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 sealed class Maks5GResultat {
-    class InnenforMaks : Maks5GResultat()
+    class InnenforMaks : Maks5GResultat() {
+        override fun equals(other: Any?): Boolean {
+            return other is InnenforMaks
+        }
+
+        override fun hashCode(): Int {
+            return javaClass.hashCode()
+        }
+
+        override fun toString(): String {
+            return this.javaClass.name
+        }
+    }
     data class OverMaks(val maksbelop: Int) : Maks5GResultat()
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/MinusbelopRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/MinusbelopRepository.kt
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface MinusbelopRepository : JpaRepository<Minusbelop, String> {
     fun findAllByAvtaleNr(avtaleNr: Int): List<Minusbelop>
+    fun findAllByAvtaleNrAndGjortOppIsFalse(avtaleNr: Int): List<Minusbelop>
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonRepository.kt
@@ -86,5 +86,21 @@ interface RefusjonRepository : JpaRepository<Refusjon, String> {
         where r.godkjentAvArbeidsgiver between (current_date - 1 year) and (current_date - 7 day) and r.status = 'SENDT_KRAV'
     """)
     fun hentRefusjonerSomIkkeErBetalt(): List<Refusjon>
+    @Query("""
+        select r from Refusjon r
+        where r.deltakerFnr = :deltakerFnr and r.bedriftNr = :bedriftNr
+          and r.refusjonsgrunnlag.tilskuddsgrunnlag.tiltakstype = :tiltakstype
+          and r.status in (:status)
+          and r.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom >= :periodeStart
+          and r.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom <= :periodeSlutt
+    """)
+    fun hentDeltakersRefusjoner(
+        deltakerFnr: String,
+        bedriftNr: String,
+        tiltakstype: Tiltakstype,
+        status: List<RefusjonStatus>,
+        periodeStart: LocalDate,
+        periodeSlutt: LocalDate
+    ): List<Refusjon>
 
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -22,7 +22,9 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.time.LocalDate
 import java.time.YearMonth
+import kotlin.time.measureTimedValue
 
 @Service
 @Observed
@@ -112,15 +114,11 @@ class RefusjonService(
      */
     fun settMinusbeløpFraTidligereRefusjonerTilknyttetAvtalen(refusjon: Refusjon) {
         val avtaleNr = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr
-        val alleMinusbeløp = minusbelopRepository.findAllByAvtaleNr(avtaleNr)
-        if (alleMinusbeløp.isNotEmpty()) {
-            val sumMinusbelop = alleMinusbeløp
-                .filter { !it.gjortOpp }
-                .mapNotNull { minusbelop -> minusbelop.beløp }
-                .sum()
-            refusjon.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(sumMinusbelop)
-            refusjonRepository.save(refusjon)
-        }
+        val alleUoppgjorteMinusbeløp = minusbelopRepository.findAllByAvtaleNrAndGjortOppIsFalse(avtaleNr)
+        val sumMinusbelop = alleUoppgjorteMinusbeløp
+            .mapNotNull { it.beløp }
+            .sum()
+        refusjon.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(sumMinusbelop)
     }
 
     /**
@@ -214,20 +212,16 @@ class RefusjonService(
             )
             refusjon.oppgiInntektsgrunnlag(inntektsgrunnlag, refusjon.refusjonsgrunnlag.inntektsgrunnlag)
             gjørBeregning(refusjon, utførtAv)
-            refusjonRepository.save(refusjon)
         } catch (e: Exception) {
             log.error("Feil ved henting av inntekter for refusjon ${refusjon.id}", e)
         }
     }
 
     fun godkjennForArbeidsgiver(refusjon: Refusjon, utførtAv: InnloggetBruker) {
-        val alleMinusBeløp = minusbelopRepository.findAllByAvtaleNr(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr)
-        val sumMinusbelop = alleMinusBeløp
-            .filter { !it.gjortOpp }
-            .mapNotNull { minusbelop -> minusbelop.beløp }
-            .reduceOrNull { sum, beløp -> sum + beløp }
+        val alleUoppgjorteMinusBeløp = minusbelopRepository.findAllByAvtaleNrAndGjortOppIsFalse(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr)
+        val sumMinusbelop = alleUoppgjorteMinusBeløp.mapNotNull { it.beløp }.sum()
         // Om det er et gammelt minusbeløp, men alle minusbeløp er gjort opp må refusjonen lastes på ny for å reberegnes
-        if (sumMinusbelop != null && sumMinusbelop != 0 && refusjon.refusjonsgrunnlag.forrigeRefusjonMinusBeløp != sumMinusbelop) {
+        if (alleUoppgjorteMinusBeløp.isNotEmpty() && sumMinusbelop != 0 && refusjon.refusjonsgrunnlag.forrigeRefusjonMinusBeløp != sumMinusbelop) {
             log.info("Arbeidsgiver prøver å sende inn en refusjon hvor minusbeløp er gjort opp/endret av annen refusjon ${refusjon.id}")
             throw FeilkodeException(Feilkode.LAST_REFUSJONEN_PÅ_NYTT_REFUSJONSGRUNNLAG_ENDRET)
         }
@@ -235,19 +229,21 @@ class RefusjonService(
         refusjon.godkjennForArbeidsgiver(utførtAv)
 
         // Gjør opp alle eventuelle minusbeløp
-        alleMinusBeløp.forEach {
-            if (!it.gjortOpp) {
-                it.gjortOpp = true
-                it.gjortOppAvRefusjonId = refusjon.id
-                minusbelopRepository.save(it)
-            }
+        alleUoppgjorteMinusBeløp.forEach {
+            it.gjortOpp = true
+            it.gjortOppAvRefusjonId = refusjon.id
+            minusbelopRepository.save(it)
         }
 
         // Lag en nytt minusbeløp om refusjonen er i minus
         if (refusjon.status == RefusjonStatus.GODKJENT_MINUSBELØP) {
+            val beregning = refusjon.refusjonsgrunnlag.beregning
+            if (beregning == null) {
+                throw FeilkodeException(Feilkode.INGEN_BEREGNING)
+            }
             val minusbelop = Minusbelop(
                 avtaleNr = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr,
-                beløp = refusjon.refusjonsgrunnlag.beregning?.refusjonsbeløp,
+                beløp = beregning.refusjonsbeløp,
                 løpenummer = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.løpenummer
             )
             refusjon.minusbelop = minusbelop
@@ -306,7 +302,6 @@ class RefusjonService(
             return
         }
         refusjon.oppgiBedriftKontonummer(kontoregisterService.hentBankkontonummer(refusjon.bedriftNr))
-        refusjonRepository.save(refusjon)
     }
 
     fun opprettKorreksjonsutkast(refusjon: Refusjon, korreksjonsgrunner: Set<Korreksjonsgrunn>, unntakOmInntekterFremitid: Int?, annetGrunn: String?): Korreksjon {
@@ -314,7 +309,7 @@ class RefusjonService(
         if (refusjon.tiltakstype() == Tiltakstype.VTAO) {
             // Utfør beregning umiddelbart for VTAO-korreksjoner
             korreksjonsutkast.refusjonsgrunnlag.beregning = beregnKorreksjon(
-                Beregningskontekst(grunnbelopService.alleGrunnbelop()),
+                hentBeregningskontekst(korreksjonsutkast),
                 korreksjonsutkast
             )
         }
@@ -372,7 +367,7 @@ class RefusjonService(
     }
 
     fun gjørBeregning(refusjon: Refusjon, utførtAv: InnloggetBruker) {
-        val beregning: Beregning? = beregnRefusjon(Beregningskontekst(grunnbelopService.alleGrunnbelop()), refusjon)
+        val beregning: Beregning? = beregnRefusjon(hentBeregningskontekst(refusjon), refusjon)
         if (beregning != null) {
             refusjon.refusjonsgrunnlag.beregning = beregning
             log.info("Oppdatert beregning på refusjon ${refusjon.id} til ${beregning.id}")
@@ -381,7 +376,7 @@ class RefusjonService(
     }
 
     fun gjørKorreksjonBeregning(korreksjon: Korreksjon, utførtAv: InnloggetBruker) {
-        val beregning = beregnKorreksjon(Beregningskontekst(grunnbelopService.alleGrunnbelop()), korreksjon)
+        val beregning = beregnKorreksjon(hentBeregningskontekst(korreksjon), korreksjon)
         if (beregning != null) {
             korreksjon.refusjonsgrunnlag.beregning = beregning
             applicationEventPublisher.publishEvent(KorreksjonBeregningUtført(korreksjon, utførtAv))
@@ -410,6 +405,52 @@ class RefusjonService(
         this.gjørBedriftKontonummeroppslag(refusjon)
         refusjon.godkjennForArbeidsgiver(utførtAv = SYSTEM_BRUKER)
         refusjonRepository.save(refusjon)
+    }
+
+    fun hentBeregningskontekst(refundering: Refundering): Beregningskontekst {
+        val (beregningskontekst, tid) = measureTimedValue {
+            Beregningskontekst(
+                grunnbelopService.alleGrunnbelop(),
+                hentRelaterteInnsendteRefunderinger(refundering),
+                minusbelopRepository.findAllByAvtaleNrAndGjortOppIsFalse(refundering.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr)
+            )
+        }
+        log.info("Hentet beregningskontekst, tok {} ms", tid.inWholeMilliseconds)
+        return beregningskontekst
+    }
+
+    /**
+     * En beregning trenger kunnskap om alle innsendte refusjoner og korreksjoner som:
+     * <ol>
+     *     <li>Gjelder for samme deltaker, bedrift og tiltakstype</li>
+     *     <li>For samme år (i tilfelle 5g-beregning)</li>
+     *     <li>For samme måned (for å sjekke om ferietrekk er trukket)</li>
+     *     <li>Ikke er en korrigert refusjon (fordi korreksjonene er inkludert)</li>
+     *     <li>Ikke har gitt minusbeløp (alle minusbeløp er inkludert separat)</li>
+     * </ol>
+     */
+    private fun hentRelaterteInnsendteRefunderinger(refundering: Refundering): List<Refundering> {
+        val tilskuddsaar = refundering.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom.year
+        val periodeStart = LocalDate.of(tilskuddsaar, 1, 1)
+        val periodeSlutt = LocalDate.of(tilskuddsaar, 12, 31)
+        val deltakersRefusjoner = refusjonRepository.hentDeltakersRefusjoner(
+            refundering.deltakerFnr,
+            refundering.bedriftNr,
+            refundering.tiltakstype(),
+            RefusjonStatus.entries.filter { it.ansesSomUtbetalt() },
+            periodeStart,
+            periodeSlutt
+        )
+        val deltakersKorreksjoner =
+            korreksjonRepository.hentDeltakersKorreksjoner(
+                refundering.deltakerFnr,
+                refundering.bedriftNr,
+                refundering.tiltakstype(),
+                behandledeKorreksjoner,
+                periodeStart,
+                periodeSlutt
+            )
+        return (deltakersRefusjoner + deltakersKorreksjoner)
     }
 }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonStatus.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonStatus.kt
@@ -1,6 +1,6 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
-enum class RefusjonStatus : RefunderingStatus {
+enum class RefusjonStatus: RefunderingStatus {
     KLAR_FOR_INNSENDING,
     FOR_TIDLIG,
     SENDT_KRAV,

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
@@ -1,8 +1,12 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 import no.nav.arbeidsgiver.tiltakrefusjon.grunnbelop.Grunnbelop
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import kotlin.math.roundToInt
+
+val logger: Logger = LoggerFactory.getLogger(RefusjonService::class.java)
 
 fun fastBeløpBeregning(
     tilskuddsgrunnlag: Tilskuddsgrunnlag,
@@ -110,6 +114,16 @@ fun beregnRefusjonsbeløp(
     var overFemGrunnbeløp = false
     if (tilskuddsgrunnlag.tiltakstype.har5gBegrensning()) {
         val resultat = beregningskontekst.gjenståendeEtterMaks5G(tilskuddFom, sumUtbetaltVarig, refusjonsbeløp)
+        val nyttResultat = beregningskontekst.gjenståendeEtterMaks5GNy(tilskuddFom, refusjonsbeløp)
+
+        if (resultat != nyttResultat) {
+            logger.warn(
+                "Obs! Ny 5g-logikk ville gitt annet resultat. Gammel: {}, ny: {}. Har korreksjoner? {}",
+                resultat,
+                nyttResultat,
+                if (beregningskontekst.innsendteRefunderinger.any { it is Korreksjon }) "ja" else "nei"
+            )
+        }
 
         if (resultat is Maks5GResultat.OverMaks) {
             refusjonsbeløp = resultat.maksbelop

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/TestData.kt
@@ -34,7 +34,9 @@ val alleGrunnbelopMap = mapOf<LocalDate, Int>(
 ).toMap(TreeMap())
 
 fun enBeregningskontekst() = Beregningskontekst(
-    alleGrunnbelop = alleGrunnbelopMap
+    alleGrunnbelop = alleGrunnbelopMap,
+    innsendteRefunderinger = emptyList(),
+    uoppgjorteMinusbelop = emptyList()
 )
 
 fun innloggetBruker(identifikator: String, rolle: BrukerRolle) = object : InnloggetBruker {

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiverTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiverTest.kt
@@ -42,6 +42,8 @@ internal class InnloggetArbeidsgiverTest(
     @Autowired
     val refusjonRepository: RefusjonRepository,
     @Autowired
+    val korreksjonRepository: KorreksjonRepository,
+    @Autowired
     val varslingRepository: VarslingRepository,
     @Autowired
     val minusbelopRepository: MinusbelopRepository,
@@ -59,9 +61,6 @@ internal class InnloggetArbeidsgiverTest(
 
     @MockkBean
     lateinit var persondataService: PersondataService
-
-    @MockkBean
-    lateinit var korreksjonRepository: KorreksjonRepository
 
     @BeforeEach
     fun setup() {
@@ -579,10 +578,10 @@ internal class InnloggetArbeidsgiverTest(
         )
 
         // Tre refusjoner med ulik avtalenr
-        val refusjon1 = opprettRefusjonOgGjørInntektoppslag(tilskuddMelding)!!
-        val refusjon2 = opprettRefusjonOgGjørInntektoppslag(tilskuddMelding2LittEldreMedLøpenummer2)!!
-        val refusjon3 = opprettRefusjonOgGjørInntektoppslag(tilskuddMelding3LittEldreMedLøpenummer3)!!
-        val refusjon4 = opprettRefusjonOgGjørInntektoppslag(tilskuddMelding4LittEldreMedLøpenummer4)!!
+        val refusjon1 = opprettRefusjonOgGjørInntektoppslag(tilskuddMelding)
+        val refusjon2 = opprettRefusjonOgGjørInntektoppslag(tilskuddMelding2LittEldreMedLøpenummer2)
+        val refusjon3 = opprettRefusjonOgGjørInntektoppslag(tilskuddMelding3LittEldreMedLøpenummer3)
+        val refusjon4 = opprettRefusjonOgGjørInntektoppslag(tilskuddMelding4LittEldreMedLøpenummer4)
 
         val refusjon1FunnetViaFinnRefusjon = innloggetArbeidsgiver.finnRefusjon(refusjon1.id)
         assertThat(refusjon1FunnetViaFinnRefusjon.refusjonsgrunnlag.forrigeRefusjonMinusBeløp).isEqualTo(0)

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonberegnerFratrekkFerieTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonberegnerFratrekkFerieTest.kt
@@ -45,14 +45,13 @@ class RefusjonberegnerFratrekkFerieTest(
     val refusjonService: RefusjonService,
     @Autowired
     val refusjonRepository: RefusjonRepository,
+    @Autowired
+    val korreksjonRepository: KorreksjonRepository,
 ) {
-    val innloggetArbeidsgiver = innloggetBruker("12345678910", BrukerRolle.ARBEIDSGIVER);
+    val innloggetArbeidsgiver = innloggetBruker("12345678910", BrukerRolle.ARBEIDSGIVER)
 
     @MockkBean
     lateinit var altinnTilgangsstyringService: AltinnTilgangsstyringService
-
-    @MockkBean
-    lateinit var korreksjonRepository: KorreksjonRepository
 
     @MockkBean
     lateinit var persondataService: PersondataService


### PR DESCRIPTION
OBS: Utvidet beregningskontekst er foreløpig ikke førende (beregner 5g og sammenligner med dagens beregning)

Vi har et mål om å skrive om beregningslogikken slik at når en beregning utføres så ser vi på alle innsendte refunderinger (refusjon+korreksjon) for å finne ut hvor mye som er utbetalt for tiltaket (5g), om ferietrekk er trukket, og om det er uoppgjorte minusbeløp.

Dette er en endring fra tidligere hvor vi oppdaterte alle åpne refusjoner med disse verdiene hver gang vi sendte inn en refusjon, men da oppdaterte vi også kun andre åpne refusjoner; korreksjoner ble aldri oppdatert.

Tanken er at det vil være enklere å vedlikeholde en løsning hvor vi henter ut nåtidsbildet ved beregning, i stedet for at vi prøver å "pushe" et nytt nåtidsbilde ved innsending av refusjon/korreksjon.