### PR TITLE
isSendtInn -> isUbehandlet

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
@@ -313,7 +313,7 @@ class AdminController(
                 RefusjonStatus.entries.filter { it.isUbehandlet() },
                 Tiltakstype.entries.filter { it.har5gBegrensning() }
             )
-            logger.info("Antall 5g-refusjoner som ikke er sendt inn: {}", refusjoner.size)
+            logger.info("Antall 5g-refusjoner som er ubehandlet: {}", refusjoner.size)
             refusjoner.forEach {
                 val bleLagtTil = alleredeSjekketTiltaksdeltakelse.add(
                     mapOf(

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
@@ -310,7 +310,7 @@ class AdminController(
         val alleredeSjekketTiltaksdeltakelse = HashSet<Map<String, String>>()
         val totalTid = measureTime {
             val refusjoner = refusjonRepository.findAllByStatusInAndRefusjonsgrunnlagTilskuddsgrunnlagTiltakstypeIn(
-                RefusjonStatus.entries.filterNot { it.isSendtInn() },
+                RefusjonStatus.entries.filter { it.isUbehandlet() },
                 Tiltakstype.entries.filter { it.har5gBegrensning() }
             )
             logger.info("Antall 5g-refusjoner som ikke er sendt inn: {}", refusjoner.size)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjonstype.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjonstype.kt
@@ -3,8 +3,10 @@ package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 enum class Korreksjonstype : RefunderingStatus {
     UTKAST, TILLEGSUTBETALING, OPPGJORT, TILBAKEKREVING, TILLEGGSUTBETALING_FEILET, TILLEGGSUTBETALING_UTBETALT;
 
-    override fun isSendtInn() = when (this) {
-        UTKAST -> false
-        TILBAKEKREVING, OPPGJORT, TILLEGSUTBETALING, TILLEGGSUTBETALING_UTBETALT, TILLEGGSUTBETALING_FEILET -> true
+    override fun isUbehandlet() = when (this) {
+        UTKAST -> true
+        TILBAKEKREVING, OPPGJORT, TILLEGSUTBETALING, TILLEGGSUTBETALING_UTBETALT, TILLEGGSUTBETALING_FEILET -> false
     }
+
+    fun isSendtInn() = !isUbehandlet()
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefunderingStatus.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefunderingStatus.kt
@@ -1,6 +1,6 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
 sealed interface RefunderingStatus {
-    fun isSendtInn(): Boolean
+    fun isUbehandlet(): Boolean
 }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -341,7 +341,7 @@ class RefusjonService(
 
     fun oppdaterRefusjon(refusjon: Refusjon, utførtAv: InnloggetBruker) {
         log.info("Oppdaterer refusjon ${refusjon.id} med data")
-        // Skal kun mutere refusjonsgrunnalget for refusjoner som skal sendes inn
+        // Skal kun mutere refusjonsgrunnlaget for refusjoner som skal sendes inn
         if (refusjon.status.isUbehandlet()) {
             settMinusbeløpFraTidligereRefusjonerTilknyttetAvtalen(refusjon)
             if (refusjon.tiltakstype().har5gBegrensning()) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -245,7 +245,7 @@ class RefusjonService(
         val alleRefusjonerSomSkalSendesInn =
             refusjonRepository.findAllByRefusjonsgrunnlag_Tilskuddsgrunnlag_AvtaleNrAndStatusIn(
                 refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr,
-                RefusjonStatus.entries.filterNot { it.isSendtInn() }
+                RefusjonStatus.entries.filter { it.isUbehandlet() }
             )
         alleRefusjonerSomSkalSendesInn.forEach {
             if (it.id != refusjon.id) {
@@ -325,7 +325,7 @@ class RefusjonService(
     }
 
     fun settOmFerieErTrukketForSammeMåned(refusjon: Refusjon) {
-        if (!refusjon.status.isSendtInn()) {
+        if (refusjon.status.isUbehandlet()) {
             val statuser = listOf(RefusjonStatus.UTBETALT, RefusjonStatus.SENDT_KRAV, RefusjonStatus.GODKJENT_MINUSBELØP, RefusjonStatus.GODKJENT_NULLBELØP)
             refusjonRepository.findAllByRefusjonsgrunnlag_Tilskuddsgrunnlag_AvtaleNrAndStatusIn(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr, statuser)
                 .filter { YearMonth.from(it.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom) == YearMonth.from(refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom) }
@@ -342,7 +342,7 @@ class RefusjonService(
     fun oppdaterRefusjon(refusjon: Refusjon, utførtAv: InnloggetBruker) {
         log.info("Oppdaterer refusjon ${refusjon.id} med data")
         // Ikke oppdater tallgrunnlag på innsendte refusjoner
-        if (!refusjon.status.isSendtInn()) {
+        if (refusjon.status.isUbehandlet()) {
             settMinusbeløpFraTidligereRefusjonerTilknyttetAvtalen(refusjon)
             if (refusjon.tiltakstype().har5gBegrensning()) {
                 refusjon.refusjonsgrunnlag.sumUtbetaltVarig = totaltUtbetaltForTiltakMed5gBegrensning(refusjon)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -341,7 +341,7 @@ class RefusjonService(
 
     fun oppdaterRefusjon(refusjon: Refusjon, utførtAv: InnloggetBruker) {
         log.info("Oppdaterer refusjon ${refusjon.id} med data")
-        // Ikke oppdater tallgrunnlag på innsendte refusjoner
+        // Skal kun mutere refusjonsgrunnalget for refusjoner som skal sendes inn
         if (refusjon.status.isUbehandlet()) {
             settMinusbeløpFraTidligereRefusjonerTilknyttetAvtalen(refusjon)
             if (refusjon.tiltakstype().har5gBegrensning()) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonStatus.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonStatus.kt
@@ -12,9 +12,9 @@ enum class RefusjonStatus : RefunderingStatus {
     UTBETALING_FEILET,
     GODKJENT_NULLBELØP;
 
-    override fun isSendtInn() = when (this) {
-        KLAR_FOR_INNSENDING, FOR_TIDLIG -> false
-        SENDT_KRAV, UTBETALT, KORRIGERT, UTGÅTT, ANNULLERT, GODKJENT_MINUSBELØP, GODKJENT_NULLBELØP, UTBETALING_FEILET -> true
+    override fun isUbehandlet() = when (this) {
+        KLAR_FOR_INNSENDING, FOR_TIDLIG -> true
+        SENDT_KRAV, UTBETALT, UTBETALING_FEILET, UTGÅTT, KORRIGERT, GODKJENT_NULLBELØP, GODKJENT_MINUSBELØP, ANNULLERT -> false
     }
 
     fun ansesSomUtbetalt() = when (this) {


### PR DESCRIPTION
Nesten alle "sendt inn"-sjekker var negative, så
det gir mer mening å ha en sjekk for "isUbehandlet".

Da slipper vi også filosofiske diskusjoner om en
refusjon som er korrigert eller annullert teller som "sendt inn".