### PR TITLE
Ikke les "deny-message" fra PoaoTilgang

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/PoaoTilgangServiceFake.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/PoaoTilgangServiceFake.kt
@@ -13,7 +13,7 @@ class PoaoTilgangServiceFake : PoaoTilgangService {
     )
 
     override fun harSkrivetilgang(beslutterAzureUUID: UUID, fnr: Fnr) = if (deny.contains(fnr)) {
-        Tilgang.Avvis(Avslagskode.entries.random(), "Ingen tilgang")
+        Tilgang.Avvis(Avslagskode.entries.random())
     } else {
         Tilgang.Tillat()
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/PoaoTilgangServiceImpl.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/PoaoTilgangServiceImpl.kt
@@ -42,11 +42,11 @@ class PoaoTilgangServiceImpl(
             return if (decision?.isPermit == true) {
                 Tilgang.Tillat()
             } else {
-                Tilgang.Avvis(Avslagskode.parse(decision), (decision as Deny).message)
+                Tilgang.Avvis(Avslagskode.parse(decision))
             }
         } catch (e: Exception) {
             log.error("Feil ved tilgangskontroll-sjekk", e)
-            return Tilgang.Avvis(Avslagskode.INGEN_RESPONS, "Ingen respons fra POAO-tilgang")
+            return Tilgang.Avvis(Avslagskode.INGEN_RESPONS)
         }
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/Tilgang.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/Tilgang.kt
@@ -9,7 +9,7 @@ interface Tilgang {
         }
     }
 
-    class Avvis(val tilgangskode: Avslagskode?, val melding: String?) : Tilgang {
+    class Avvis(val tilgangskode: Avslagskode?) : Tilgang {
         override fun erTillat(): Boolean {
             return false
         }


### PR DESCRIPTION
Fikk en feil i loggene hvor vi forsøkte å parse en "null-decision" for å hente ut feilbeskjeden, og fikk feilmelding.

Men etter en del omskrivninger har vi ikke lenger behov for å lese ut feil-beskjeden, så den enkleste fiksen er å bare fjerne denne castingen.