### PR TITLE
Fiks diffus bug i JPA relatert Inntektslinje 

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Inntektsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Inntektsgrunnlag.kt
@@ -17,7 +17,7 @@ data class Inntektsgrunnlag(
         @JsonIgnore
         val respons: String?,
 ) {
-    val bruttoLønn: Double? = inntekter.filter { it.erMedIInntektsgrunnlag() }.sumOf { it.beløp }
+    val bruttoLønn: Double = inntekter.filter { it.erMedIInntektsgrunnlag() }.sumOf { it.beløp }
     constructor(inntekter: List<Inntektslinje>, respons: String?) : this(inntekter.toMutableSet(), respons)
 
     @Id

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Inntektsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Inntektsgrunnlag.kt
@@ -13,12 +13,12 @@ import java.time.LocalDateTime
 @Entity
 data class Inntektsgrunnlag(
         @OneToMany(mappedBy = "inntektsgrunnlag", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-        val inntekter: Set<Inntektslinje>,
+        val inntekter: MutableSet<Inntektslinje>,
         @JsonIgnore
         val respons: String?,
 ) {
     val bruttoLønn: Double? = inntekter.filter { it.erMedIInntektsgrunnlag() }.sumOf { it.beløp }
-    constructor(inntekter: List<Inntektslinje>, respons: String?) : this(inntekter.toSet(), respons)
+    constructor(inntekter: List<Inntektslinje>, respons: String?) : this(inntekter.toMutableSet(), respons)
 
     @Id
     val id: String = ulid()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Inntektslinje.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Inntektslinje.kt
@@ -49,10 +49,10 @@ data class Inntektslinje(
 
 }
 
-val inkluderteFratrekkbeskrivelser = listOf<String>("trekkILoennForFerie")
+val inkluderteFratrekkbeskrivelser = setOf("trekkILoennForFerie")
 // Dette er verdier som settes av inntektskomponenten
 // https://github.com/navikt/inntektskomponenten/blob/a2ea187cc77c43ef696ecba98b7b06f69ebc75d6/inntektskomponenten-core/src/main/java/no/nav/inntektskomponenten/domain/kodeverk/beskrivelser/LoennsinntektBeskrivelser.java
-val inkluderteLønnsbeskrivelser = listOf(
+val inkluderteLønnsbeskrivelser = setOf(
     "fastloenn",
     "timeloenn",
     "fastTillegg",


### PR DESCRIPTION
Inntekter som ligger i Inntektsgrunnlag er definert som
et immutable set. Diverse lint-warnings har advart om
hvordan våre JPA-entiteter er definert (feks at inntekter
skal være et mutable sett, og at JPA-entiteter ikke bør
være data-classes).

Det ser ut som at en warning slo ut i feil nå, da en
endring som virker helt urelatert plutselig førte til at
vi fikk en UnsupportedOperationException pga fjerning
av inntektslinjer fra dette settet.