### PR TITLE
Opprettet-tidspunkt for refusjoner

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -82,6 +82,7 @@ class Refusjon(
     @OneToOne(orphanRemoval = true, cascade = [CascadeType.ALL])
     var minusbelop: Minusbelop? = null
     var sistEndret: Instant? = null
+    val opprettetTidspunkt: Instant? = Instant.now()
 
     init {
         oppdaterStatus()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -82,7 +82,7 @@ class Refusjon(
     @OneToOne(orphanRemoval = true, cascade = [CascadeType.ALL])
     var minusbelop: Minusbelop? = null
     var sistEndret: Instant? = null
-    val opprettetTidspunkt: Instant? = Instant.now()
+    val opprettetTidspunkt: Instant? = Now.instant()
 
     init {
         oppdaterStatus()

--- a/src/main/resources/db/migration/V63__refusjon_opprettet_tidspunkt.sql
+++ b/src/main/resources/db/migration/V63__refusjon_opprettet_tidspunkt.sql
@@ -1,1 +1,7 @@
 alter table refusjon add column opprettet_tidspunkt TIMESTAMP WITH TIME ZONE;
+
+update refusjon
+set opprettet_tidspunkt =
+        (select hendelseslogg.tidspunkt at time zone 'UTC'
+         from hendelseslogg
+         where hendelseslogg.refusjon_id = refusjon.id and hendelseslogg.event = 'RefusjonOpprettet');

--- a/src/main/resources/db/migration/V63__refusjon_opprettet_tidspunkt.sql
+++ b/src/main/resources/db/migration/V63__refusjon_opprettet_tidspunkt.sql
@@ -1,0 +1,1 @@
+alter table refusjon add column opprettet_tidspunkt TIMESTAMP WITH TIME ZONE;


### PR DESCRIPTION
Vi har noen brukerstøttesaker hvor det er et behov for å utvide fristen forbi tidspunktet hvor beslutter har godkjent, fordi det er en resending av en gammel refusjon hvor beslutter godkjente for lenge siden.

Men ettersom vi aldri har tatt vare på når refusjoner ble opprettet, blir det veldig vanskelig å tilpasse logikken slik at vi kan si at fristen kan baseres på når refusjonen ble opprettet (hvis det er lenge etter beslutter godkjente)