### PR TITLE
Unngå at resendinger umiddelbart blir satt som utgått

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -143,8 +143,8 @@ class Refusjon(
      * fortsatt har en "åpen" status.
      */
     fun oppdaterStatus(tillatUtgaatt: Boolean = true) {
-        val statuserSomIkkeKanEndres =
-            listOf(RefusjonStatus.SENDT_KRAV, RefusjonStatus.ANNULLERT, RefusjonStatus.UTBETALT, RefusjonStatus.UTGÅTT)
+        val statuserSomIkkeKanEndres = RefusjonStatus.entries
+            .filterNot { it.isUbehandlet() }
         if (::status.isInitialized && status in statuserSomIkkeKanEndres) return
 
         val today = Now.localDate()

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -84,7 +84,7 @@ class Refusjon(
     var sistEndret: Instant? = null
 
     init {
-        oppdaterStatus()
+        oppdaterStatus(tillatUtgaatt = false)
         registerEvent(RefusjonOpprettet(this, SYSTEM_BRUKER))
     }
 
@@ -137,13 +137,18 @@ class Refusjon(
         registerEvent(RefusjonUtgått(this))
     }
 
-    fun oppdaterStatus() {
+    /**
+     * Oppdaterer statusen til refusjonen. Når en refusjon opprettes ønsker vi å unngå at man setter status til
+     * utgått umiddelbart; det er noen tilfeller hvor vi feks utsetter fristen, og da er vi avhengig av at refusjonen
+     * fortsatt har en "åpen" status.
+     */
+    fun oppdaterStatus(tillatUtgaatt: Boolean = true) {
         val statuserSomIkkeKanEndres =
             listOf(RefusjonStatus.SENDT_KRAV, RefusjonStatus.ANNULLERT, RefusjonStatus.UTBETALT, RefusjonStatus.UTGÅTT)
         if (::status.isInitialized && status in statuserSomIkkeKanEndres) return
 
         val today = Now.localDate()
-        if (today.isAfter(fristForGodkjenning)) {
+        if (today.isAfter(fristForGodkjenning) && tillatUtgaatt) {
             settRefusjonUtgått()
             return
         }
@@ -381,13 +386,23 @@ class Refusjon(
         ) else antallMånederEtter(tidligsteFrist, 1)
     }
 
+    /**
+     * Dersom refusjoner ikke har gått ut på frist enda kan vi tillate forlenging inntil en maks dato. Kan overstyres
+     * ved et bool-flagg.
+     * <p>
+     * OBS: I et særtilfelle der vi resender utgåtte refusjoner er vi nødt til å unngå at status oppdateres FØR vi
+     * får forlenget! Derfor har vi et bool-flagg som gjør at vi skipper "oppdaterStatus"-kallet i denne metoden.
+     */
     fun forlengFrist(
         nyFrist: LocalDate,
         årsak: String,
         utførtAv: InnloggetBruker,
-        tillatLengerEnnMaksimalFrist: Boolean = false
+        tillatLengerEnnMaksimalFrist: Boolean = false,
+        oppdaterStatusPaaForhaand: Boolean = true
     ) {
-        oppdaterStatus()
+        if (oppdaterStatusPaaForhaand) {
+            oppdaterStatus()
+        }
         krevStatus(RefusjonStatus.FOR_TIDLIG, RefusjonStatus.KLAR_FOR_INNSENDING)
 
         if (nyFrist <= fristForGodkjenning) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -15,6 +15,7 @@ import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.MidlerFrigjortÅrsak
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeAnnullertMelding
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeForkortetMelding
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeGodkjentMelding
+import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
@@ -83,9 +84,22 @@ class RefusjonService(
             deltakerFnr = tilskuddsperiodeGodkjentMelding.deltakerFnr,
             bedriftNr = tilskuddsperiodeGodkjentMelding.bedriftNr
         )
+        val toMndFraDagensDato = Now.localDate().plusMonths(2)
+        if (tilskuddsperiodeGodkjentMelding.resendingsnummer != null &&
+            toMndFraDagensDato.isAfter(refusjon.finnTidligsteFristForGodkjenning())
+        ) {
+            refusjon.forlengFrist(
+                toMndFraDagensDato,
+                "Ekstraordinær forlengelse i forbindelse med resending",
+                SYSTEM_BRUKER,
+                true,
+                false
+            )
+        }
 
         refusjon.refusjonsgrunnlag.bedriftKid = tilskuddsperiodeGodkjentMelding.arbeidsgiverKid
 
+        refusjon.oppdaterStatus()
         oppdaterRefusjon(refusjon, SYSTEM_BRUKER)
 
         return refusjonRepository.save(refusjon)

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
@@ -387,7 +390,7 @@ class RefusjonServiceTest(
     }
 
     @Test
-    internal fun `inntektsoppslag skal ta hensyn til unntaksregel`() {
+    fun `inntektsoppslag skal ta hensyn til unntaksregel`() {
         val deltakerFnr = "00000000000"
         val tilskuddMelding = TilskuddsperiodeGodkjentMelding(
             avtaleId = "2",
@@ -447,7 +450,7 @@ class RefusjonServiceTest(
     }
 
     @Test
-    internal fun `inntektsoppslag skal ta hensyn til at arbeidsgiver klikker på knapp for å hente neste måneds inntekter`() {
+    fun `inntektsoppslag skal ta hensyn til at arbeidsgiver klikker på knapp for å hente neste måneds inntekter`() {
         val deltakerFnr = "00000000000"
         val tilskuddMelding = TilskuddsperiodeGodkjentMelding(
             avtaleId = "2",
@@ -494,7 +497,6 @@ class RefusjonServiceTest(
         }
 
         Now.fixedDate(LocalDate.now().plusDays(1))
-        //refusjon.merkForUnntakOmInntekterToMånederFrem(true, "")
         refusjon.merkForHentInntekterFrem(true, innloggetSaksbehandler)
         refusjonService.gjørInntektsoppslag(refusjon, innloggetArbeidsgiver)
         verify {
@@ -620,45 +622,59 @@ class RefusjonServiceTest(
         assertThat(lagretRefusjon.status).isNotEqualTo(RefusjonStatus.ANNULLERT)
     }
 
-    @Test
-    fun `godkjenner etterregistrert VTAO tilskuddsperiode gir refusjon med status for tidlig`() {
-        val deltakerFnr = "00000000000"
-        val tilskuddMelding = TilskuddsperiodeGodkjentMelding(
-            avtaleId = "1",
-            tilskuddsbeløp = 5000,
-            tiltakstype = Tiltakstype.VTAO,
-            deltakerEtternavn = "Mus",
-            deltakerFornavn = "Mikke",
-            arbeidsgiverFornavn = "Arne",
-            arbeidsgiverEtternavn = "Arbeidsgiver",
-            arbeidsgiverTlf = "41111111",
-            arbeidsgiveravgiftSats = 0.0,
-            avtaleInnholdId = "1",
-            bedriftNavn = "Bedriften AS",
-            bedriftNr = "999999999",
-            deltakerFnr = deltakerFnr,
-            feriepengerSats = 0.0,
-            otpSats = 0.0,
-            tilskuddFom = Now.localDate().minusWeeks(4),
-            tilskuddTom = Now.localDate().minusDays(1),
-            tilskuddsperiodeId = "1",
-            veilederNavIdent = "X123456",
-            lønnstilskuddsprosent = 0,
-            avtaleNr = 3456,
-            løpenummer = 1,
-            resendingsnummer = null,
-            enhet = "1000",
-            godkjentTidspunkt = LocalDateTime.now(),
-            arbeidsgiverKontonummer = "12345678908",
-            arbeidsgiverKid = null,
-            mentorTimelonn = null,
-            mentorAntallTimer = null,
-        )
-        val refusjon = refusjonService.opprettRefusjon(tilskuddMelding)!!
+    @ParameterizedTest(name = "{0} blir {1}")
+    @MethodSource("no.nav.arbeidsgiver.tiltakrefusjon.refusjon.RefusjonServiceTestKt#parameterargumenterTiltakstypeTilRefusjonsstatusVedEtterregistrering")
+fun `tilskuddsperioder som er ettersendt men ikke utgått får riktig status ved opprettelse`(
+        tiltakstype: Tiltakstype,
+        refusjonStatus: RefusjonStatus,
+    ) {
+        val refusjon = refusjonService.opprettRefusjon(
+            eldreTilskuddsmeldingBase.copy(
+                tiltakstype = tiltakstype,
+                tilskuddFom = YearMonth.from(Now.localDate().minusMonths(1)).atDay(1),
+                tilskuddTom = YearMonth.from(Now.localDate().minusMonths(1)).atEndOfMonth(),
+                godkjentTidspunkt = LocalDateTime.now().minusMonths(2),
+            )
+        )!!
+
+        val lagretRefusjon = requireNotNull(refusjonRepository.findByIdOrNull(refusjon.id))
+        assertThat(lagretRefusjon.status).isEqualTo(refusjonStatus)
+    }
+
+    @ParameterizedTest(name = "{0} blir UTGÅTT")
+    @MethodSource("no.nav.arbeidsgiver.tiltakrefusjon.refusjon.RefusjonServiceTestKt#parameterargumenterTiltakstypeTilRefusjonsstatusVedEtterregistrering")
+    fun `tilskuddsperioder som ble godkjent for lenge siden blir utgått ved opprettelse`(
+        tiltakstype: Tiltakstype
+    ) {
+        val refusjon = refusjonService.opprettRefusjon(
+            eldreTilskuddsmeldingBase.copy(
+                tiltakstype = tiltakstype,
+                tilskuddFom = YearMonth.from(Now.localDate().minusMonths(6)).atDay(1),
+                tilskuddTom = YearMonth.from(Now.localDate().minusMonths(6)).atEndOfMonth(),
+                godkjentTidspunkt = LocalDateTime.now().minusMonths(5),
+                )
+        )!!
+
+        val lagretRefusjon = requireNotNull(refusjonRepository.findByIdOrNull(refusjon.id))
+        assertThat(lagretRefusjon.status).isEqualTo(RefusjonStatus.UTGÅTT)
+    }
+
+    @ParameterizedTest
+    @MethodSource("no.nav.arbeidsgiver.tiltakrefusjon.refusjon.RefusjonServiceTestKt#parameterargumenterTiltakstypeTilRefusjonsstatusVedEtterregistrering")
+    fun `resendte tilskuddsperioder som ble godkjent for lenge siden teller som etterregistrert`(
+        tiltakstype: Tiltakstype,
+        forventetStatus: RefusjonStatus
+    ) {
+        val refusjon = refusjonService.opprettRefusjon(
+            eldreTilskuddsmeldingBase.copy(
+                tiltakstype = tiltakstype,
+                resendingsnummer = 1
+            )
+        )!!
 
         val lagretRefusjon = refusjonRepository.findByIdOrNull(refusjon.id)
         if (lagretRefusjon != null) {
-            assertThat(lagretRefusjon.status).isEqualTo(RefusjonStatus.FOR_TIDLIG)
+            assertThat(lagretRefusjon.status).isEqualTo(forventetStatus)
         }
     }
 
@@ -671,4 +687,47 @@ class RefusjonServiceTest(
         refusjonService.gjørBeregning(refusjon, innloggetArbeidsgiver)
     }
 
+}
+
+private val eldreTilskuddsmeldingBase = TilskuddsperiodeGodkjentMelding(
+    avtaleId = "1",
+    tilskuddsbeløp = 5000,
+    tiltakstype = Tiltakstype.VTAO,
+    deltakerEtternavn = "Mus",
+    deltakerFornavn = "Mikke",
+    arbeidsgiverFornavn = "Arne",
+    arbeidsgiverEtternavn = "Arbeidsgiver",
+    arbeidsgiverTlf = "41111111",
+    arbeidsgiveravgiftSats = 0.0,
+    avtaleInnholdId = "1",
+    bedriftNavn = "Bedriften AS",
+    bedriftNr = "999999999",
+    deltakerFnr = "00000000000",
+    feriepengerSats = 0.0,
+    otpSats = 0.0,
+    tilskuddFom = Now.localDate().minusMonths(6).withDayOfMonth(1),
+    tilskuddTom = YearMonth.from(Now.localDate().minusMonths(6)).atEndOfMonth(),
+    tilskuddsperiodeId = "1",
+    veilederNavIdent = "X123456",
+    lønnstilskuddsprosent = 0,
+    avtaleNr = 3456,
+    løpenummer = 1,
+    resendingsnummer = null,
+    enhet = "1000",
+    // Etterregistrert, men for lenge siden
+    godkjentTidspunkt = LocalDateTime.now().minusMonths(5),
+    arbeidsgiverKontonummer = "12345678908",
+    arbeidsgiverKid = null,
+    mentorTimelonn = null,
+    mentorAntallTimer = null,
+)
+
+private fun statusVedEtterregistrering(tiltakstype: Tiltakstype): RefusjonStatus =
+    when (tiltakstype) {
+        Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD, Tiltakstype.VARIG_LONNSTILSKUDD, Tiltakstype.SOMMERJOBB, Tiltakstype.FIREARIG_LONNSTILSKUDD -> RefusjonStatus.KLAR_FOR_INNSENDING
+        Tiltakstype.VTAO, Tiltakstype.MENTOR -> RefusjonStatus.FOR_TIDLIG
+    }
+
+private fun parameterargumenterTiltakstypeTilRefusjonsstatusVedEtterregistrering() = Tiltakstype.entries.map {
+    Arguments.of(it, statusVedEtterregistrering(it))
 }


### PR DESCRIPTION
Vi har noen brukerstøttesaker hvor en del automatiske utbetalinger
ikke har gått igjennom, og det har vart så lenge at noen av disse
refusjonene har blitt satt til utgått.

De skal nå utbetales via resending, men når man resender gamle
tilskuddsperioder så baserer vi oss på godkjenningstidspunkt
til beslutter for å sette utløpsfrist.
Med andre ord går nyopprettede refusjoner over frist, og settes 
til utgått før de har en sjanse til å behandles.

Dette løser vi ved å legge til en ekstraordinær forlengelse som kun
utføres ved resending (foreløpig).