### PR TITLE
fix. ikke logg som error for kjente feil

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/aktsomhet/AktsomhetService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/aktsomhet/AktsomhetService.kt
@@ -1,5 +1,7 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.aktsomhet
 
+import no.nav.arbeidsgiver.tiltakrefusjon.FeilkodeException
+import no.nav.arbeidsgiver.tiltakrefusjon.RessursFinnesIkkeException
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBrukerService
 import no.nav.arbeidsgiver.tiltakrefusjon.persondata.PersondataService
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
@@ -20,7 +22,9 @@ class AktsomhetService(
             val diskresjonskode = persondataService.hentDiskresjonskode(refusjon.deltakerFnr)
             return Aktsomhet.av(diskresjonskode, isArbeidsgiver)
         } catch (e: Exception) {
-            log.error("Feil ved henting av Aktsomhet på refusjon med id $id", e)
+            if (e !is FeilkodeException && e !is RessursFinnesIkkeException) {
+                log.error("Feil ved henting av Aktsomhet på refusjon med id $id", e)
+            }
             return Aktsomhet.tom()
         }
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
@@ -222,12 +222,12 @@ data class InnloggetArbeidsgiver(
 
     private fun sjekkHarTilgangTilRefusjonerForBedrift(bedriftNr: String, deltakerFnr: String) {
         if (organisasjoner.none { it.organizationNumber == bedriftNr }) {
-            throw TilgangskontrollException()
+            throw TilgangskontrollException(Feilkode.IKKE_TILGANG_TIL_REFUSJON)
         }
 
         val diskresjonskode = persondataService.hentDiskresjonskode(deltakerFnr)
         if (diskresjonskode.erKode6Eller7() && adresseSperretilganger.none { it.organizationNumber == bedriftNr }) {
-            throw TilgangskontrollException()
+            throw TilgangskontrollException(Feilkode.IKKE_TILGANG_TIL_REFUSJON)
         }
     }
 


### PR DESCRIPTION
FeilkodeException og RessursFinnesIkkeException håndteres stille mens øvrige feil logges. Det er fordi disse er kjente feil som håndteres på frontenden.