### PR TITLE
Sist endret korreksjon

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -279,6 +279,7 @@ data class InnloggetSaksbehandler(
     }
 
     fun settFratrekkRefunderbarBeløp(id: String, fratrekkRefunderbarBeløp: Boolean, refunderbarBeløp: Int?) {
+        sjekkKorreksjonTilgang()
         val korreksjon: Korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         korreksjon.settFratrekkRefunderbarBeløp(fratrekkRefunderbarBeløp, refunderbarBeløp)
@@ -288,17 +289,19 @@ data class InnloggetSaksbehandler(
     }
 
     fun overstyrMinusbeløp(id: String, minusBeløp: Int) {
+        sjekkKorreksjonTilgang()
         val korreksjon: Korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         korreksjon.refusjonsgrunnlag.forrigeRefusjonMinusBeløp = minusBeløp
-        refusjonService.gjørKorreksjonBeregning(korreksjon, this);
+        refusjonService.gjørKorreksjonBeregning(korreksjon, this)
     }
 
     fun overstyrHarFerietrekkForSammeMåned(id: String, harFerietrekkForSammeMåned: Boolean) {
+        sjekkKorreksjonTilgang()
         val korreksjon: Korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         korreksjon.refusjonsgrunnlag.harFerietrekkForSammeMåned = harFerietrekkForSammeMåned
-        refusjonService.gjørKorreksjonBeregning(korreksjon, this);
+        refusjonService.gjørKorreksjonBeregning(korreksjon, this)
     }
 
     fun hentEnhet(enhet: String): String? {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -176,14 +176,14 @@ data class InnloggetSaksbehandler(
         }
     }
 
-    private fun sjekkKorreksjonTilgang() {
+    private fun sjekkSkrivetilgang() {
         if (!harKorreksjonTilgang) {
             throw TilgangskontrollException()
         }
     }
 
     fun opprettKorreksjonsutkast(id: String, korreksjonsgrunner: Set<Korreksjonsgrunn>, unntakOmInntekterFremitid: Int?, annetGrunn: String?): Refusjon {
-        sjekkKorreksjonTilgang()
+        sjekkSkrivetilgang()
         val refusjonSomSkalKorrigeres = finnRefusjon(id)
         log.info("Oppretter korreksjonsutkast fra refusjon med id ${refusjonSomSkalKorrigeres.id} og status ${refusjonSomSkalKorrigeres.status}")
         refusjonService.opprettKorreksjonsutkast(refusjonSomSkalKorrigeres, korreksjonsgrunner, unntakOmInntekterFremitid, annetGrunn)
@@ -191,7 +191,7 @@ data class InnloggetSaksbehandler(
     }
 
     fun slettKorreksjonsutkast(id: String) {
-        sjekkKorreksjonTilgang()
+        sjekkSkrivetilgang()
         val korreksjon = finnKorreksjon(id)
         sjekkLesetilgang(korreksjon)
         val refusjon = finnRefusjon(korreksjon.korrigererRefusjonId)
@@ -204,7 +204,7 @@ data class InnloggetSaksbehandler(
     }
 
     fun utbetalKorreksjon(id: String) {
-        sjekkKorreksjonTilgang()
+        sjekkSkrivetilgang()
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         val refusjon = finnRefusjon(korreksjon.korrigererRefusjonId)
@@ -218,7 +218,7 @@ data class InnloggetSaksbehandler(
     }
 
     fun fullførKorreksjonVedOppgjort(id: String) {
-        sjekkKorreksjonTilgang()
+        sjekkSkrivetilgang()
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         val refusjon = finnRefusjon(korreksjon.korrigererRefusjonId)
@@ -232,7 +232,7 @@ data class InnloggetSaksbehandler(
     }
 
     fun fullførKorreksjonVedTilbakekreving(id: String) {
-        sjekkKorreksjonTilgang()
+        sjekkSkrivetilgang()
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         val refusjon = finnRefusjon(korreksjon.korrigererRefusjonId)
@@ -246,7 +246,7 @@ data class InnloggetSaksbehandler(
     }
 
     fun endreBruttolønn(id: String, inntekterKunFraTiltaket: Boolean?, endretBruttoLønn: Int?) {
-        sjekkKorreksjonTilgang()
+        sjekkSkrivetilgang()
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         korreksjon.endreBruttolønn(inntekterKunFraTiltaket, endretBruttoLønn)
@@ -269,7 +269,7 @@ data class InnloggetSaksbehandler(
     }
 
     fun setInntektslinjeTilOpptjentIPeriode(korreksjonId: String, inntekslinjeId: String, erOpptjentIPeriode: Boolean) {
-        sjekkKorreksjonTilgang()
+        sjekkSkrivetilgang()
         val korreksjon = korreksjonRepository.findByIdOrNull(korreksjonId) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         korreksjon.setInntektslinjeTilOpptjentIPeriode(inntekslinjeId, erOpptjentIPeriode)
@@ -279,7 +279,7 @@ data class InnloggetSaksbehandler(
     }
 
     fun settFratrekkRefunderbarBeløp(id: String, fratrekkRefunderbarBeløp: Boolean, refunderbarBeløp: Int?) {
-        sjekkKorreksjonTilgang()
+        sjekkSkrivetilgang()
         val korreksjon: Korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         korreksjon.settFratrekkRefunderbarBeløp(fratrekkRefunderbarBeløp, refunderbarBeløp)
@@ -289,7 +289,7 @@ data class InnloggetSaksbehandler(
     }
 
     fun overstyrMinusbeløp(id: String, minusBeløp: Int) {
-        sjekkKorreksjonTilgang()
+        sjekkSkrivetilgang()
         val korreksjon: Korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         korreksjon.refusjonsgrunnlag.forrigeRefusjonMinusBeløp = minusBeløp
@@ -297,7 +297,7 @@ data class InnloggetSaksbehandler(
     }
 
     fun overstyrHarFerietrekkForSammeMåned(id: String, harFerietrekkForSammeMåned: Boolean) {
-        sjekkKorreksjonTilgang()
+        sjekkSkrivetilgang()
         val korreksjon: Korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
         korreksjon.refusjonsgrunnlag.harFerietrekkForSammeMåned = harFerietrekkForSammeMåned

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -15,6 +15,7 @@ import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Inntektsgrunnlag
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjon
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.KorreksjonRepository
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjonsgrunn
+import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refundering
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.RefusjonRepository
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.RefusjonService
@@ -168,15 +169,8 @@ data class InnloggetSaksbehandler(
         return korreksjon
     }
 
-    private fun sjekkLesetilgang(refusjon: Refusjon) {
-        val tilgang = tilgangskontrollService.harLeseTilgang(internIdentifikatorer, refusjon.deltakerFnr)
-        if (tilgang is Tilgang.Avvis) {
-            throw TilgangskontrollException.fraAvvisning(tilgang)
-        }
-    }
-
-    private fun sjekkLesetilgang(korreksjon: Korreksjon) {
-        val tilgang = tilgangskontrollService.harLeseTilgang(internIdentifikatorer, korreksjon.deltakerFnr)
+    private fun sjekkLesetilgang(refundering: Refundering) {
+        val tilgang = tilgangskontrollService.harLeseTilgang(internIdentifikatorer, refundering.deltakerFnr)
         if (tilgang is Tilgang.Avvis) {
             throw TilgangskontrollException.fraAvvisning(tilgang)
         }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
@@ -81,6 +81,7 @@ class Korreksjon(
     var godkjentTidspunkt: Instant? = null
     var besluttetAvNavIdent: String? = null
     var besluttetTidspunkt: Instant? = null
+    var sistEndret: Instant? = null
 
     @JsonProperty
     fun harTattStillingTilAlleInntektslinjer(): Boolean =

--- a/src/main/resources/db/migration/V63__korreksjon_sist_endret.sql
+++ b/src/main/resources/db/migration/V63__korreksjon_sist_endret.sql
@@ -1,0 +1,1 @@
+alter table korreksjon add column sist_endret timestamp with time zone default null;

--- a/src/main/resources/db/migration/V64__tidssone_for_sist_endret.sql
+++ b/src/main/resources/db/migration/V64__tidssone_for_sist_endret.sql
@@ -1,0 +1,4 @@
+-- sist_endret-feltet har ikke tidssone i databasen, men er en instant i jpa-entiteten.
+-- Instants er tidspunkter med tidssoner, så kolonnen burde også ha tidssone.
+alter table refusjon alter column sist_endret type timestamp with time zone
+    using sist_endret at time zone 'UTC';


### PR DESCRIPTION
## Sammenslå sjekkLesetilgang

Refusjoner og korreksjoner deler et interface, så her
kan vi fjerne litt duplisert logikk

## Legg til sist_endret for korreksjoner

Refusjoner har et felt for sist_endret, som brukes feks til å
kaste feilmelding hvis brukere forsøker å endre refusjoner som
har blitt endret.

Korreksjoner har ikke et slikt felt, og vil dermed ikke kunne
gi saksbehandlere feilmelding dersom de feks godkjenner en
utbetaling der grunnlaget har endret seg fordi en bruker har
sendt inn en refusjon (feks at beløpet ble redusert pga 5g)

## Legg til tidssone på sist_endret-feltet i refusjonstabell

JPA-entiteten definerer sistEndret som en instant, så databasen
bør beholde tiddsone-informasjon også.