### PR TITLE
lagId funksjon uten T-

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/rapport/UbetaltFaktura.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/rapport/UbetaltFaktura.kt
@@ -39,7 +39,7 @@ fun lagId(avtaleNr: Int, løpenummer: Int, korreksjonsnummer: Int?, resendingsnu
         "T-${avtaleNr}-$løpenummer"
     }
 }
-/** lagerErstatter forhåpentligvis lagId når oeBs er klare for det **/
+/** Erstatter forhåpentligvis lagId når oeBs er klare for det **/
 fun lagRefusjonsnummer(avtaleNr: Int, løpenummer: Int, korreksjonsnummer: Int?, resendingsnummer: Int?): String {
     return if (korreksjonsnummer != null && resendingsnummer != null) {
         "${avtaleNr}-$løpenummer-K$korreksjonsnummer-R$resendingsnummer"

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/rapport/UbetaltFaktura.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/rapport/UbetaltFaktura.kt
@@ -42,12 +42,12 @@ fun lagId(avtaleNr: Int, løpenummer: Int, korreksjonsnummer: Int?, resendingsnu
 /** Erstatter forhåpentligvis lagId når oeBs er klare for det **/
 fun lagRefusjonsnummer(avtaleNr: Int, løpenummer: Int, korreksjonsnummer: Int?, resendingsnummer: Int?): String {
     return if (korreksjonsnummer != null && resendingsnummer != null) {
-        "${avtaleNr}-$løpenummer-K$korreksjonsnummer-R$resendingsnummer"
+        "$avtaleNr-$løpenummer-K$korreksjonsnummer-R$resendingsnummer"
     } else if (korreksjonsnummer != null) {
-        "${avtaleNr}-$løpenummer-K$korreksjonsnummer"
+        "$avtaleNr-$løpenummer-K$korreksjonsnummer"
     } else if (resendingsnummer != null) {
-        "${avtaleNr}-$løpenummer-R$resendingsnummer"
+        "$avtaleNr-$løpenummer-R$resendingsnummer"
     } else {
-        "${avtaleNr}-$løpenummer"
+        "$avtaleNr-$løpenummer"
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/rapport/UbetaltFaktura.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/rapport/UbetaltFaktura.kt
@@ -39,3 +39,15 @@ fun lagId(avtaleNr: Int, løpenummer: Int, korreksjonsnummer: Int?, resendingsnu
         "T-${avtaleNr}-$løpenummer"
     }
 }
+// Erstatter forhåpentligvis lagId når oeBs er klare for det
+fun lagIdV2(avtaleNr: Int, løpenummer: Int, korreksjonsnummer: Int?, resendingsnummer: Int?): String {
+    return if (korreksjonsnummer != null && resendingsnummer != null) {
+        "${avtaleNr}-$løpenummer-K$korreksjonsnummer-R$resendingsnummer"
+    } else if (korreksjonsnummer != null) {
+        "${avtaleNr}-$løpenummer-K$korreksjonsnummer"
+    } else if (resendingsnummer != null) {
+        "${avtaleNr}-$løpenummer-R$resendingsnummer"
+    } else {
+        "${avtaleNr}-$løpenummer"
+    }
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/rapport/UbetaltFaktura.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/rapport/UbetaltFaktura.kt
@@ -39,8 +39,8 @@ fun lagId(avtaleNr: Int, løpenummer: Int, korreksjonsnummer: Int?, resendingsnu
         "T-${avtaleNr}-$løpenummer"
     }
 }
-// Erstatter forhåpentligvis lagId når oeBs er klare for det
-fun lagIdV2(avtaleNr: Int, løpenummer: Int, korreksjonsnummer: Int?, resendingsnummer: Int?): String {
+/** lagerErstatter forhåpentligvis lagId når oeBs er klare for det **/
+fun lagRefusjonsnummer(avtaleNr: Int, løpenummer: Int, korreksjonsnummer: Int?, resendingsnummer: Int?): String {
     return if (korreksjonsnummer != null && resendingsnummer != null) {
         "${avtaleNr}-$løpenummer-K$korreksjonsnummer-R$resendingsnummer"
     } else if (korreksjonsnummer != null) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/varsling/RefusjonVarselProducer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/varsling/RefusjonVarselProducer.kt
@@ -1,8 +1,7 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.varsling
 
 import no.nav.arbeidsgiver.tiltakrefusjon.Topics
-import no.nav.arbeidsgiver.tiltakrefusjon.rapport.lagId
-import no.nav.arbeidsgiver.tiltakrefusjon.rapport.lagIdV2
+import no.nav.arbeidsgiver.tiltakrefusjon.rapport.lagRefusjonsnummer
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -43,7 +42,7 @@ class RefusjonVarselProducer(
             løpenummer = løpenummer,
             tilskuddFom = tilskuddFom,
             tilskuddTom = tilskuddTom,
-            refusjonsnummer = lagIdV2(avtaleNr, løpenummer, korreksjonsnummer, resendingsnummer),
+            refusjonsnummer = lagRefusjonsnummer(avtaleNr, løpenummer, korreksjonsnummer, resendingsnummer),
             resendingsnummer = resendingsnummer,
 
         )

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/varsling/RefusjonVarselProducer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/varsling/RefusjonVarselProducer.kt
@@ -2,6 +2,7 @@ package no.nav.arbeidsgiver.tiltakrefusjon.varsling
 
 import no.nav.arbeidsgiver.tiltakrefusjon.Topics
 import no.nav.arbeidsgiver.tiltakrefusjon.rapport.lagId
+import no.nav.arbeidsgiver.tiltakrefusjon.rapport.lagIdV2
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -42,7 +43,7 @@ class RefusjonVarselProducer(
             løpenummer = løpenummer,
             tilskuddFom = tilskuddFom,
             tilskuddTom = tilskuddTom,
-            refusjonsnummer = lagId(avtaleNr, løpenummer, korreksjonsnummer, resendingsnummer),
+            refusjonsnummer = lagIdV2(avtaleNr, løpenummer, korreksjonsnummer, resendingsnummer),
             resendingsnummer = resendingsnummer,
 
         )


### PR DESCRIPTION
ny `lagId()` funksjon som ikke har med `T-`.
Brukes foreløpig kun  til å lage `refusjonsnummer` på varslingsmeldingen som sendes på topic til tiltak-notifikajson, men kan kanskje erstatte dagens lagId på sikt, når evt. oeBs sier ok.