### PR TITLE
Trekk fra "tidligere utbetalt" helt til sist

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjon.kt
@@ -329,7 +329,7 @@ class Refusjon(
             return refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddsbeløp
         } else {
             if (refusjonsgrunnlag.beregning == null) {
-                return 0;
+                return 0
             } else {
                 return refusjonsgrunnlag.beregning!!.refusjonsbeløp
             }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Refusjonsberegner.kt
@@ -108,7 +108,7 @@ fun beregnRefusjonsbeløp(
 
     val overTilskuddsbeløp = avrundetBeregnetBeløp > tilskuddsgrunnlag.tilskuddsbeløp
     var refusjonsbeløp: Int =
-        (if (overTilskuddsbeløp) tilskuddsgrunnlag.tilskuddsbeløp else avrundetBeregnetBeløp) - tidligereUtbetalt + forrigeRefusjonMinusBeløp
+        (if (overTilskuddsbeløp) tilskuddsgrunnlag.tilskuddsbeløp else avrundetBeregnetBeløp) + forrigeRefusjonMinusBeløp
     val grunnbelopForPerioden: Grunnbelop = beregningskontekst.grunnbelopForPerioden(tilskuddFom)
 
     var overFemGrunnbeløp = false
@@ -130,6 +130,9 @@ fun beregnRefusjonsbeløp(
             overFemGrunnbeløp = true
         }
     }
+
+    // Hvis vi korrigerer vil det være et utbetalt beløp på den korrigerte refusjonen som vi må trekke fra til sist
+    refusjonsbeløp = refusjonsbeløp - tidligereUtbetalt
 
     return Beregning(
         lønn = lønn,


### PR DESCRIPTION
Når vi skal rydde opp i feilen der korreksjoner ikke bryr seg om 5G-begrensninger, vil vi få en feil fordi vi trekker fra refusjonsbeløpet fra refusjonen FØR vi sjekker for 5G, som i praksis betyr at vi sjekker mot et annet beløp enn vi gjorde når vi beregnet den opprinnelige refusjonen.

Løsningen er å utføre alle beregninger helt likt hele veien, men så trekke fra tidligere utbetalt beløp helt til slutt.