### PR TITLE
Flytt korreksjonslogikk til servicelag

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetBrukerService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetBrukerService.kt
@@ -97,8 +97,6 @@ class InnloggetBrukerService(
                     refusjonRepository = refusjonRepository,
                     korreksjonRepository = korreksjonRepository,
                     refusjonService = refusjonService,
-                    inntektskomponentService = inntektskomponentService,
-                    kontoregisterService = kontoregisterService,
                     adGruppeTilganger = AdGruppeTilganger.av(adGrupperConfig, context),
                     norgeService = norgService,
                     persondataService = persondataService,

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -11,7 +11,6 @@ import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BegrensetRefusjon
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Beregning
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BrukerRolle
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.HentSaksbehandlerRefusjonerQueryParametre
-import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Inntektsgrunnlag
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjon
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.KorreksjonRepository
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjonsgrunn
@@ -42,8 +41,6 @@ data class InnloggetSaksbehandler(
     @JsonIgnore val refusjonRepository: RefusjonRepository,
     @JsonIgnore val korreksjonRepository: KorreksjonRepository,
     @JsonIgnore val refusjonService: RefusjonService,
-    @JsonIgnore val inntektskomponentService: InntektskomponentService,
-    @JsonIgnore val kontoregisterService: KontoregisterService,
     @JsonIgnore val adGruppeTilganger: AdGruppeTilganger,
     @JsonIgnore val persondataService: PersondataService,
     @JsonIgnore val grunnbelopService: GrunnbelopService,
@@ -135,38 +132,21 @@ data class InnloggetSaksbehandler(
     fun finnKorreksjon(id: String): Korreksjon {
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
+        var erOppdatert = false
         if (korreksjon.skalGjøreKontonummerOppslag()) {
-            val kontonummer = kontoregisterService.hentBankkontonummer(korreksjon.bedriftNr)
-            korreksjon.refusjonsgrunnlag.oppgiBedriftKontonummer(kontonummer)
-            korreksjonRepository.save(korreksjon)
+            refusjonService.gjørBedriftKontonummeroppslag(korreksjon)
+            erOppdatert = true
         }
         if (korreksjon.skalGjøreInntektsoppslag()) {
-            var antallMånederSomSkalSjekkes: Long = 1
-            if (korreksjon.korreksjonsgrunner.contains(Korreksjonsgrunn.HENT_INNTEKTER_TO_MÅNEDER_FREM)) {
-                val unntakOmInntekterFremitid = korreksjon.unntakOmInntekterFremitid
-                if (unntakOmInntekterFremitid != null) {
-                    antallMånederSomSkalSjekkes = unntakOmInntekterFremitid.toLong()
-                } else {
-                    antallMånederSomSkalSjekkes = 2
-                }
-            }
-
-            val inntektsoppslag = inntektskomponentService.hentInntekter(
-                fnr = korreksjon.deltakerFnr,
-                bedriftnummerDetSøkesPå = korreksjon.bedriftNr,
-                datoFra = korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
-                datoTil = korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom.plusMonths(antallMånederSomSkalSjekkes)
-            )
-            val inntektsgrunnlag = Inntektsgrunnlag(
-                inntekter = inntektsoppslag.first,
-                respons = inntektsoppslag.second
-            )
-            korreksjon.oppgiInntektsgrunnlag(inntektsgrunnlag)
-            refusjonService.gjørKorreksjonBeregning(korreksjon, this)
-            korreksjonRepository.save(korreksjon)
+            refusjonService.gjørInntektsoppslag(korreksjon, this)
+            erOppdatert = true
         }
-        return korreksjon
-    }
+        return if (erOppdatert) {
+            korreksjonRepository.save(korreksjon)
+        } else {
+            korreksjon
+        }
+     }
 
     private fun sjekkLesetilgang(refusjon: Refusjon) {
         val tilgang = tilgangskontrollService.harLeseTilgang(internIdentifikatorer, refusjon.deltakerFnr)

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -3,9 +3,7 @@ package no.nav.arbeidsgiver.tiltakrefusjon.autorisering
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.arbeidsgiver.tiltakrefusjon.RessursFinnesIkkeException
 import no.nav.arbeidsgiver.tiltakrefusjon.grunnbelop.GrunnbelopService
-import no.nav.arbeidsgiver.tiltakrefusjon.inntekt.InntektskomponentService
 import no.nav.arbeidsgiver.tiltakrefusjon.norg.NorgService
-import no.nav.arbeidsgiver.tiltakrefusjon.okonomi.KontoregisterService
 import no.nav.arbeidsgiver.tiltakrefusjon.persondata.PersondataService
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.BegrensetRefusjon
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Beregning
@@ -32,6 +30,7 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDate
 import java.util.*
+
 data class InnloggetSaksbehandler(
     override val identifikator: String,
     val azureOid: UUID,

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/Korreksjon.kt
@@ -114,7 +114,7 @@ class Korreksjon(
     }
 
     fun skalGjøreInntektsoppslag(): Boolean {
-        if (status != Korreksjonstype.UTKAST) {
+        if (status.isSendtInn()) {
             return false
         }
         if (this.tiltakstype().harFastUtbetalingssum())

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -332,7 +332,9 @@ class RefusjonService(
             return
         }
         val kontonummer = kontoregisterService.hentBankkontonummer(korreksjon.bedriftNr)
-        korreksjon.refusjonsgrunnlag.oppgiBedriftKontonummer(kontonummer)
+        if (kontonummer !== null) {
+            korreksjon.oppgiBedriftKontonummer(kontonummer)
+        }
     }
 
     fun gjørBedriftKontonummeroppslag(refusjon: Refusjon) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -184,6 +184,36 @@ class RefusjonService(
         return gammelBeregnetSum
     }
 
+    fun gjørInntektsoppslag(korreksjon: Korreksjon, utfortAv: InnloggetBruker) {
+        if (!korreksjon.skalGjøreInntektsoppslag()) {
+            return
+        }
+        var antallMånederSomSkalSjekkes: Long = 1
+        if (korreksjon.korreksjonsgrunner.contains(Korreksjonsgrunn.HENT_INNTEKTER_TO_MÅNEDER_FREM)) {
+            val unntakOmInntekterFremitid = korreksjon.unntakOmInntekterFremitid
+            if (unntakOmInntekterFremitid != null) {
+                antallMånederSomSkalSjekkes = unntakOmInntekterFremitid.toLong()
+            } else {
+                antallMånederSomSkalSjekkes = 2
+            }
+        }
+
+        val inntektsoppslag = inntektskomponentService.hentInntekter(
+            fnr = korreksjon.deltakerFnr,
+            bedriftnummerDetSøkesPå = korreksjon.bedriftNr,
+            datoFra = korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddFom,
+            datoTil = korreksjon.refusjonsgrunnlag.tilskuddsgrunnlag.tilskuddTom.plusMonths(
+                antallMånederSomSkalSjekkes
+            )
+        )
+        val inntektsgrunnlag = Inntektsgrunnlag(
+            inntekter = inntektsoppslag.first,
+            respons = inntektsoppslag.second
+        )
+        korreksjon.oppgiInntektsgrunnlag(inntektsgrunnlag)
+        gjørKorreksjonBeregning(korreksjon, utfortAv)
+    }
+
     fun gjørInntektsoppslag(refusjon: Refusjon, utførtAv: InnloggetBruker) {
         if (!refusjon.skalGjøreInntektsoppslag()) {
             return
@@ -295,6 +325,14 @@ class RefusjonService(
             } ?: run {
             log.warn("Kunne ikke forkorte refusjon med tilskuddsperiodeId ${melding.tilskuddsperiodeId}, fant ikke refusjonen")
         }
+    }
+
+    fun gjørBedriftKontonummeroppslag(korreksjon: Korreksjon) {
+        if (!korreksjon.skalGjøreKontonummerOppslag()) {
+            return
+        }
+        val kontonummer = kontoregisterService.hentBankkontonummer(korreksjon.bedriftNr)
+        korreksjon.refusjonsgrunnlag.oppgiBedriftKontonummer(kontonummer)
     }
 
     fun gjørBedriftKontonummeroppslag(refusjon: Refusjon) {

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandlerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandlerTest.kt
@@ -50,8 +50,6 @@ class InnloggetSaksbehandlerTest(
         refusjonRepository,
         korreksjonRepository,
         refusjonService,
-        inntektskomponentService,
-        kontoregisterService,
         AdGruppeTilganger(
             beslutter = true,
             korreksjon = true,


### PR DESCRIPTION
I InnloggetSaksbehandler ligger logikk for henting av kontonummer og inntektsoppslag. For å forenkle testing, og for å kunne behandle korreksjoner og refusjoner stadig mer likt, flytter vi denne logikken til samme nivå som tilsvarende logikk for refusjoner.

Dette forenkler også ny testkode, som kommer senere.