### PR TITLE
Korreksjoner skal ta høyde for 5G-grense

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
@@ -113,7 +113,6 @@ class AdminController(
                 annetGrunn = null,
                 SYSTEM_BRUKER
             )
-            // korreksjoner.add(korreksjon.id)
         }
         return korreksjoner
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
@@ -2,12 +2,12 @@ package no.nav.arbeidsgiver.tiltakrefusjon
 
 import no.nav.arbeidsgiver.tiltakrefusjon.automatisk_utbetaling.AutomatiskInnsendingService
 import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.ADMIN_BRUKER
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.SYSTEM_BRUKER
 import no.nav.arbeidsgiver.tiltakrefusjon.grunnbelop.GrunnbelopService
 import no.nav.arbeidsgiver.tiltakrefusjon.leader.LeaderPodCheck
 import no.nav.arbeidsgiver.tiltakrefusjon.okonomi.KontoregisterServiceImpl
 import no.nav.arbeidsgiver.tiltakrefusjon.rapport.UbetaltRefusjonRapport
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Beregning
-import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Beregningskontekst
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Korreksjonsgrunn
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.Refusjon
 import no.nav.arbeidsgiver.tiltakrefusjon.refusjon.RefusjonKafkaProducer
@@ -39,7 +39,6 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
 import kotlin.time.measureTime
-import kotlin.time.measureTimedValue
 
 @ProtectedWithClaims(issuer = "azure-access-token", claimMap = ["groups=fb516b74-0f2e-4b62-bad8-d70b82c3ae0b"])
 @RestController
@@ -107,7 +106,13 @@ class AdminController(
         for (id in korreksjonRequest.refusjonIder) {
             val refusjon =
                 refusjonRepository.findByIdOrNull(id) ?: throw RuntimeException("Finner ikke refusjon med id=$id")
-            service.opprettKorreksjonsutkast(refusjon, korreksjonRequest.korreksjonsgrunner, 2, annetGrunn = null)
+            service.opprettKorreksjonsutkast(
+                refusjon,
+                korreksjonRequest.korreksjonsgrunner,
+                2,
+                annetGrunn = null,
+                SYSTEM_BRUKER
+            )
             // korreksjoner.add(korreksjon.id)
         }
         return korreksjoner

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/AdminController.kt
@@ -106,7 +106,7 @@ class AdminController(
         for (id in korreksjonRequest.refusjonIder) {
             val refusjon =
                 refusjonRepository.findByIdOrNull(id) ?: throw RuntimeException("Finner ikke refusjon med id=$id")
-            service.opprettKorreksjonsutkast(
+            service.opprettOgLagreKorreksjonsutkast(
                 refusjon,
                 korreksjonRequest.korreksjonsgrunner,
                 2,

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiver.kt
@@ -158,9 +158,7 @@ data class InnloggetArbeidsgiver(
         val refusjon: Refusjon = refusjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkHarTilgangTilRefusjonerForBedrift(refusjon.bedriftNr, refusjon.deltakerFnr)
         sjekkSistEndret(refusjon, sistEndret)
-        refusjonService.endreBruttolønn(refusjon, inntekterKunFraTiltaket, bruttoLønn)
-        refusjonService.gjørBeregning(refusjon, this)
-        refusjonService.oppdaterSistEndret(refusjon)
+        refusjonService.endreBruttolønn(refusjon, inntekterKunFraTiltaket, bruttoLønn, this)
         refusjonRepository.save(refusjon)
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -165,7 +165,7 @@ data class InnloggetSaksbehandler(
         sjekkKorreksjonTilgang()
         val refusjonSomSkalKorrigeres = finnRefusjon(id)
         log.info("Oppretter korreksjonsutkast fra refusjon med id ${refusjonSomSkalKorrigeres.id} og status ${refusjonSomSkalKorrigeres.status}")
-        refusjonService.opprettKorreksjonsutkast(refusjonSomSkalKorrigeres, korreksjonsgrunner, unntakOmInntekterFremitid, annetGrunn, this)
+        refusjonService.opprettOgLagreKorreksjonsutkast(refusjonSomSkalKorrigeres, korreksjonsgrunner, unntakOmInntekterFremitid, annetGrunn, this)
         return refusjonSomSkalKorrigeres
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetSaksbehandler.kt
@@ -165,7 +165,7 @@ data class InnloggetSaksbehandler(
         sjekkKorreksjonTilgang()
         val refusjonSomSkalKorrigeres = finnRefusjon(id)
         log.info("Oppretter korreksjonsutkast fra refusjon med id ${refusjonSomSkalKorrigeres.id} og status ${refusjonSomSkalKorrigeres.status}")
-        refusjonService.opprettKorreksjonsutkast(refusjonSomSkalKorrigeres, korreksjonsgrunner, unntakOmInntekterFremitid, annetGrunn)
+        refusjonService.opprettKorreksjonsutkast(refusjonSomSkalKorrigeres, korreksjonsgrunner, unntakOmInntekterFremitid, annetGrunn, this)
         return refusjonSomSkalKorrigeres
     }
 
@@ -228,9 +228,7 @@ data class InnloggetSaksbehandler(
         sjekkKorreksjonTilgang()
         val korreksjon = korreksjonRepository.findByIdOrNull(id) ?: throw RessursFinnesIkkeException()
         sjekkLesetilgang(korreksjon)
-        korreksjon.endreBruttolønn(inntekterKunFraTiltaket, endretBruttoLønn)
-        refusjonService.gjørBeregning(korreksjon, this)
-
+        refusjonService.endreBruttolønn(korreksjon, inntekterKunFraTiltaket, endretBruttoLønn, this)
         korreksjonRepository.save(korreksjon)
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -354,7 +354,7 @@ class RefusjonService(
         refusjon.oppgiBedriftKontonummer(kontoregisterService.hentBankkontonummer(refusjon.bedriftNr))
     }
 
-    fun opprettKorreksjonsutkast(
+    fun opprettOgLagreKorreksjonsutkast(
         refusjon: Refusjon,
         korreksjonsgrunner: Set<Korreksjonsgrunn>,
         unntakOmInntekterFremitid: Int?,

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -148,7 +148,7 @@ class RefusjonService(
                 refundering.tiltakstype()
             ).let { refusjoner ->
                 when (refundering) {
-                    // Hvis refunderingen er en korreksjon må vi ignorere refusjonen som er i ferd med å korrigeres
+                    // Ikke tell med refusjonen som korreksjonen er basert på - da vil summen bli for høy
                     is Korreksjon -> refusjoner.filter { it.korreksjonId != refundering.id }
                     is Refusjon -> refusjoner
                 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -434,8 +434,8 @@ class RefusjonService(
                 refundering.refusjonsgrunnlag.sumUtbetaltVarig = totaltUtbetaltForTiltakMed5gBegrensning(refundering)
             }
             settOmFerieErTrukketForSammeMåned(refundering)
-            oppdaterSistEndret(refundering)
             gjørBeregning(refundering, utførtAv)
+            oppdaterSistEndret(refundering)
         }
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 import java.time.LocalDate
 import java.time.YearMonth
 import kotlin.time.measureTimedValue
@@ -112,13 +111,18 @@ class RefusjonService(
      * men at vi overfører minusbeløp til neste måned dersom tiltaket fortsetter måneden etter. Hvis tiltaket avsluttes den samme måneden hvor det går i minus,
      * så går refusjonen bare i 0,-.
      */
-    fun settMinusbeløpFraTidligereRefusjonerTilknyttetAvtalen(refusjon: Refusjon) {
-        val avtaleNr = refusjon.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr
-        val alleUoppgjorteMinusbeløp = minusbelopRepository.findAllByAvtaleNrAndGjortOppIsFalse(avtaleNr)
-        val sumMinusbelop = alleUoppgjorteMinusbeløp
-            .mapNotNull { it.beløp }
-            .sum()
-        refusjon.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(sumMinusbelop)
+    fun settMinusbeløpFraTidligereRefusjonerTilknyttetAvtalen(refundering: Refundering) {
+        when (refundering) {
+            is Korreksjon -> return // Korreksjoner baserer seg på minusbeløpet til refusjonen som ble korrigert
+            is Refusjon -> {
+                val avtaleNr = refundering.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr
+                val alleUoppgjorteMinusbeløp = minusbelopRepository.findAllByAvtaleNrAndGjortOppIsFalse(avtaleNr)
+                val sumMinusbelop = alleUoppgjorteMinusbeløp
+                    .mapNotNull { it.beløp }
+                    .sum()
+                refundering.refusjonsgrunnlag.oppgiForrigeRefusjonsbeløp(sumMinusbelop)
+            }
+        }
     }
 
     /**
@@ -142,7 +146,13 @@ class RefusjonService(
                 refundering.bedriftNr,
                 utbetalteRefusjonsstatuser,
                 refundering.tiltakstype()
-            )
+            ).let { refusjoner ->
+                when (refundering) {
+                    // Hvis refunderingen er en korreksjon må vi ignorere refusjonen som er i ferd med å korrigeres
+                    is Korreksjon -> refusjoner.filter { it.korreksjonId != refundering.id }
+                    is Refusjon -> refusjoner
+                }
+            }
         val utbetalteKorreksjoner =
             korreksjonRepository.findAllByDeltakerFnrAndBedriftNrAndStatusInAndRefusjonsgrunnlag_Tilskuddsgrunnlag_Tiltakstype(
                 refundering.deltakerFnr,
@@ -344,17 +354,19 @@ class RefusjonService(
         refusjon.oppgiBedriftKontonummer(kontoregisterService.hentBankkontonummer(refusjon.bedriftNr))
     }
 
-    fun opprettKorreksjonsutkast(refusjon: Refusjon, korreksjonsgrunner: Set<Korreksjonsgrunn>, unntakOmInntekterFremitid: Int?, annetGrunn: String?): Korreksjon {
-        val korreksjonsutkast = refusjon.opprettKorreksjonsutkast(korreksjonsgrunner, unntakOmInntekterFremitid, annetGrunn)
-        if (refusjon.tiltakstype() == Tiltakstype.VTAO) {
-            // Utfør beregning umiddelbart for VTAO-korreksjoner
-            korreksjonsutkast.refusjonsgrunnlag.beregning = beregnKorreksjon(
-                hentBeregningskontekst(korreksjonsutkast),
-                korreksjonsutkast
-            )
-        }
+    fun opprettKorreksjonsutkast(
+        refusjon: Refusjon,
+        korreksjonsgrunner: Set<Korreksjonsgrunn>,
+        unntakOmInntekterFremitid: Int?,
+        annetGrunn: String?,
+        utfortAv: InnloggetBruker
+    ): Korreksjon {
+        val korreksjonsutkast =
+            refusjon.opprettKorreksjonsutkast(korreksjonsgrunner, unntakOmInntekterFremitid, annetGrunn)
         korreksjonRepository.save(korreksjonsutkast)
         refusjonRepository.save(refusjon)
+        oppdaterRefundering(korreksjonsutkast, utfortAv)
+        korreksjonRepository.save(korreksjonsutkast)
         return korreksjonsutkast
     }
 
@@ -388,6 +400,13 @@ class RefusjonService(
         }
     }
 
+    fun settOmFerieErTrukketForSammeMåned(refundering: Refundering) {
+        when (refundering) {
+            is Korreksjon -> return
+            is Refusjon -> settOmFerieErTrukketForSammeMåned(refundering)
+        }
+    }
+
     fun oppdaterRefusjon(refusjon: Refusjon, utførtAv: InnloggetBruker) {
         log.info("Oppdaterer refusjon ${refusjon.id} med data")
         // Skal kun mutere refusjonsgrunnlaget for refusjoner som skal sendes inn
@@ -402,8 +421,29 @@ class RefusjonService(
         }
     }
 
-    fun oppdaterSistEndret(refusjon: Refusjon) {
-        refusjon.sistEndret = Instant.now()
+    fun oppdaterRefundering(refundering: Refundering, utførtAv: InnloggetBruker) {
+        when (refundering) {
+            is Refusjon -> log.info("Oppdaterer refusjon ${refundering.id} med data")
+            is Korreksjon -> log.info("Oppdaterer korreksjon ${refundering.id} med data")
+        }
+
+        // Skal kun mutere refunderingsgrunnlaget for refunderinger som skal sendes inn
+        if (refundering.status.isUbehandlet()) {
+            settMinusbeløpFraTidligereRefusjonerTilknyttetAvtalen(refundering)
+            if (refundering.tiltakstype().har5gBegrensning()) {
+                refundering.refusjonsgrunnlag.sumUtbetaltVarig = totaltUtbetaltForTiltakMed5gBegrensning(refundering)
+            }
+            settOmFerieErTrukketForSammeMåned(refundering)
+            oppdaterSistEndret(refundering)
+            gjørBeregning(refundering, utførtAv)
+        }
+    }
+
+    fun oppdaterSistEndret(refundering: Refundering) {
+        when (refundering) {
+            is Korreksjon -> Unit
+            is Refusjon -> refundering.sistEndret = Now.instant()
+        }
     }
 
     private fun gjørRefusjonsberegning(refusjon: Refusjon, utførtAv: InnloggetBruker) {
@@ -430,8 +470,18 @@ class RefusjonService(
         }
     }
 
-    fun endreBruttolønn(refusjon: Refusjon, inntekterKunFraTiltaket: Boolean?, bruttoLønn: Int?) {
-        refusjon.endreBruttolønn(inntekterKunFraTiltaket, bruttoLønn)
+    fun endreBruttolønn(
+        refundering: Refundering,
+        inntekterKunFraTiltaket: Boolean?,
+        bruttoLønn: Int?,
+        utfortAv: InnloggetBruker
+    ) {
+        when (refundering) {
+            is Refusjon -> refundering.endreBruttolønn(inntekterKunFraTiltaket, bruttoLønn)
+            is Korreksjon -> refundering.endreBruttolønn(inntekterKunFraTiltaket, bruttoLønn)
+        }
+        gjørBeregning(refundering, utfortAv)
+        oppdaterSistEndret(refundering)
     }
 
     @Transactional

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiverTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/autorisering/InnloggetArbeidsgiverTest.kt
@@ -758,11 +758,9 @@ internal class InnloggetArbeidsgiverTest(
         refusjon.refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }
             ?.forEach { it.erOpptjentIPeriode = true }
         // Bekreft at alle inntektene kun er fra tiltaket
-        refusjonService.endreBruttolønn(refusjon, true, null)
-        refusjonService.gjørBeregning(refusjon, innloggetArbeidsgiverBruker)
+        refusjonService.endreBruttolønn(refusjon, true, null, innloggetArbeidsgiverBruker)
 
-        refusjonRepository.save(refusjon)
-        return refusjon;
+        return refusjonRepository.save(refusjon)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonberegnerFratrekkFerieTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/inntekt/RefusjonberegnerFratrekkFerieTest.kt
@@ -114,11 +114,9 @@ class RefusjonberegnerFratrekkFerieTest(
         refusjon.refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }
             ?.forEach { it.erOpptjentIPeriode = true }
         // Bekreft at alle inntektene kun er fra tiltaket
-        //refusjonService.oppdaterRefusjon(refusjon)
-        refusjonService.endreBruttolønn(refusjon, true, null)
-        refusjonService.gjørBeregning(refusjon, innloggetArbeidsgiver);
+        refusjonService.endreBruttolønn(refusjon, true, null, innloggetArbeidsgiver)
 
-        return refusjon;
+        return refusjon
     }
 
     fun `vis utregning med feriefratrekk`(refusjon: Refusjon, TREKKFORFERIEGRUNNLAG: Int): Int {

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonServiceTest.kt
@@ -683,8 +683,7 @@ fun `tilskuddsperioder som er ettersendt men ikke utgått får riktig status ved
         refusjon.refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }
             ?.forEach { it.erOpptjentIPeriode = true }
         // Bekreft at alle inntektene kun er fra tiltaket
-        refusjonService.endreBruttolønn(refusjon, true, null)
-        refusjonService.gjørBeregning(refusjon, innloggetArbeidsgiver)
+        refusjonService.endreBruttolønn(refusjon, true, null, innloggetArbeidsgiver)
     }
 
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
@@ -212,7 +212,7 @@ class RefusjonVarig5GTest(
         )
     }
 
-    private fun gjørInntektoppslagForRefundering(refundering: Refundering, utfortAv: InnloggetBruker) {
+    private fun velgAlleInntektslinjer(refundering: Refundering, utfortAv: InnloggetBruker) {
         // Sett innhentede inntekter til opptjent i periode
         refundering.refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }?.forEach { it.erOpptjentIPeriode = true }
         // Bekreft at alle inntektene kun er fra tiltaket
@@ -228,7 +228,7 @@ class RefusjonVarig5GTest(
         val oppdatertRefusjon = refusjonRepository.findById(refusjon.id).get()
         refusjonService.gjørBedriftKontonummeroppslag(oppdatertRefusjon)
         refusjonService.gjørInntektsoppslag(oppdatertRefusjon, innloggetArbeidsgiver)
-        gjørInntektoppslagForRefundering(oppdatertRefusjon, innloggetArbeidsgiver)
+        velgAlleInntektslinjer(oppdatertRefusjon, innloggetArbeidsgiver)
         val oppdatertRefusjonIgjen = refusjonRepository.findById(oppdatertRefusjon.id).get()
         refusjonService.godkjennForArbeidsgiver(oppdatertRefusjonIgjen, innloggetArbeidsgiver)
         refusjonRepository.save(oppdatertRefusjonIgjen)
@@ -238,7 +238,7 @@ class RefusjonVarig5GTest(
         val oppdatertKorreksjon = korreksjonRepository.findById(korreksjon.id).get()
         refusjonService.gjørBedriftKontonummeroppslag(oppdatertKorreksjon)
         refusjonService.gjørInntektsoppslag(oppdatertKorreksjon, innloggetSaksbehandler)
-        gjørInntektoppslagForRefundering(oppdatertKorreksjon, innloggetSaksbehandler)
+        velgAlleInntektslinjer(oppdatertKorreksjon, innloggetSaksbehandler)
         val oppdatertKorreksjonIgjen = korreksjonRepository.findById(oppdatertKorreksjon.id).get()
         refusjonService.gjørBeregning(oppdatertKorreksjonIgjen, innloggetSaksbehandler)
         oppdatertKorreksjonIgjen.fullførKorreksjonVedOppgjort(innloggetSaksbehandler)

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
@@ -126,45 +126,6 @@ class RefusjonVarig5GTest(
     }
 
     @Test
-    fun `en 5g-korreksjon arver samme sumUtbetaltVarig som refusjonen den korrigerer`() {
-        listOf(
-            tilskuddsmelding,
-            tilskuddsmelding.medNyId("februar").medNyPeriode(2024, 2),
-            tilskuddsmelding.medNyId("mars").medNyPeriode(2024, 3),
-            tilskuddsmelding.medNyId("april").medNyPeriode(2024, 4),
-            tilskuddsmelding.medNyId("mai").medNyPeriode(2024, 5),
-            tilskuddsmelding.medNyId("juni").medNyPeriode(2024, 6)
-        ).map { it.opprettRefusjonMedJustertTid() }.forEach { godkjennRefusjonMedJustertTid(it) }
-
-        val alleRefusjoner = refusjonRepository.findAll()
-        val maiKorreksjonsutkast = refusjonService.opprettKorreksjonsutkast(
-            alleRefusjoner.tilskuddsperiode("mai"),
-            setOf(Korreksjonsgrunn.ANNEN_GRUNN),
-            null,
-            null,
-            innloggetSaksbehandler
-        )
-
-        assertEquals(
-            alleRefusjoner.tilskuddsperiode("mai").refusjonsgrunnlag.sumUtbetaltVarig,
-            maiKorreksjonsutkast.refusjonsgrunnlag.sumUtbetaltVarig
-        )
-
-        val juniKorreksjonsutkast = refusjonService.opprettKorreksjonsutkast(
-            alleRefusjoner.tilskuddsperiode("juni"),
-            setOf(Korreksjonsgrunn.ANNEN_GRUNN),
-            null,
-            null,
-            innloggetSaksbehandler
-        )
-
-        assertEquals(
-            alleRefusjoner.tilskuddsperiode("juni").refusjonsgrunnlag.sumUtbetaltVarig,
-            juniKorreksjonsutkast.refusjonsgrunnlag.sumUtbetaltVarig
-        )
-    }
-
-    @Test
     fun `en 5g-korrigering vil resultere i samme sum som refusjonen`() {
         listOf(
             tilskuddsmelding,
@@ -187,6 +148,10 @@ class RefusjonVarig5GTest(
         val godkjentMaiKorreksjon = godkjennKorreksjonNullbelopMedJustertTid(maiKorreksjonsutkast)
         val maiBeregning = godkjentMaiKorreksjon.refusjonsgrunnlag.beregning
 
+        assertEquals(
+            alleRefusjoner.tilskuddsperiode("mai").refusjonsgrunnlag.sumUtbetaltVarig,
+            maiKorreksjonsutkast.refusjonsgrunnlag.sumUtbetaltVarig
+        )
         assertNotNull(maiBeregning)
         assertEquals(
             alleRefusjoner.tilskuddsperiode("mai").refusjonsgrunnlag.beregning?.refusjonsbeløp,
@@ -204,8 +169,11 @@ class RefusjonVarig5GTest(
         val godkjentJuniKorreksjon = godkjennKorreksjonNullbelopMedJustertTid(juniKorreksjonsutkast)
         val godkjentJuniBeregning = godkjentJuniKorreksjon.refusjonsgrunnlag.beregning
 
+        assertEquals(
+            alleRefusjoner.tilskuddsperiode("juni").refusjonsgrunnlag.sumUtbetaltVarig,
+            juniKorreksjonsutkast.refusjonsgrunnlag.sumUtbetaltVarig
+        )
         assertNotNull(godkjentJuniBeregning)
-
         assertEquals(
             alleRefusjoner.tilskuddsperiode("juni").refusjonsgrunnlag.beregning?.refusjonsbeløp,
             godkjentJuniBeregning.refusjonsbeløp + godkjentJuniKorreksjon.refusjonsgrunnlag.tidligereUtbetalt

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
@@ -137,7 +137,7 @@ class RefusjonVarig5GTest(
         ).map { it.opprettRefusjonMedJustertTid() }.forEach { godkjennRefusjonMedJustertTid(it) }
 
         val alleRefusjoner = refusjonRepository.findAll()
-        val maiKorreksjonsutkast = refusjonService.opprettKorreksjonsutkast(
+        val maiKorreksjonsutkast = refusjonService.opprettOgLagreKorreksjonsutkast(
             alleRefusjoner.tilskuddsperiode("mai"),
             setOf(Korreksjonsgrunn.ANNEN_GRUNN),
             null,
@@ -158,7 +158,7 @@ class RefusjonVarig5GTest(
             maiBeregning.refusjonsbeløp + godkjentMaiKorreksjon.refusjonsgrunnlag.tidligereUtbetalt
         )
 
-        val juniKorreksjonsutkast = refusjonService.opprettKorreksjonsutkast(
+        val juniKorreksjonsutkast = refusjonService.opprettOgLagreKorreksjonsutkast(
             alleRefusjoner.tilskuddsperiode("juni"),
             setOf(Korreksjonsgrunn.ANNEN_GRUNN),
             null,

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
@@ -1,11 +1,14 @@
 package no.nav.arbeidsgiver.tiltakrefusjon.refusjon
 
+import no.nav.arbeidsgiver.tiltakrefusjon.autorisering.InnloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.innloggetBruker
 import no.nav.arbeidsgiver.tiltakrefusjon.tilskuddsperiode.TilskuddsperiodeGodkjentMelding
 import no.nav.arbeidsgiver.tiltakrefusjon.utils.Now
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
@@ -27,13 +30,17 @@ class RefusjonVarig5GTest(
     private val refusjonService: RefusjonService,
     @param:Autowired
     private val refusjonRepository: RefusjonRepository,
+    @param:Autowired
+    private val korreksjonRepository: KorreksjonRepository,
 ) {
     @AfterEach
     fun teardown() {
         Now.resetClock()
     }
 
-    val innloggetArbeidsgiver = innloggetBruker("12345678901", BrukerRolle.ARBEIDSGIVER);
+    val innloggetArbeidsgiver = innloggetBruker("12345678901", BrukerRolle.ARBEIDSGIVER)
+    val innloggetSaksbehandler = innloggetBruker("X123456", BrukerRolle.BESLUTTER)
+
 
     @Test
     fun `refusjon som overskrider 5g fører til redusert utbetaling`() {
@@ -118,13 +125,102 @@ class RefusjonVarig5GTest(
         assertThat(alleRefusjoner.tilskuddsperiode("juni").refusjonsbeløp()).isEqualTo(0)
     }
 
-    private fun gjørInntektoppslagForRefusjon(refusjon: Refusjon) {
+    @Test
+    fun `en 5g-korreksjon arver samme sumUtbetaltVarig som refusjonen den korrigerer`() {
+        listOf(
+            tilskuddsmelding,
+            tilskuddsmelding.medNyId("februar").medNyPeriode(2024, 2),
+            tilskuddsmelding.medNyId("mars").medNyPeriode(2024, 3),
+            tilskuddsmelding.medNyId("april").medNyPeriode(2024, 4),
+            tilskuddsmelding.medNyId("mai").medNyPeriode(2024, 5),
+            tilskuddsmelding.medNyId("juni").medNyPeriode(2024, 6)
+        ).map { it.opprettRefusjonMedJustertTid() }.forEach { godkjennRefusjonMedJustertTid(it) }
+
+        val alleRefusjoner = refusjonRepository.findAll()
+        val maiKorreksjonsutkast = refusjonService.opprettKorreksjonsutkast(
+            alleRefusjoner.tilskuddsperiode("mai"),
+            setOf(Korreksjonsgrunn.ANNEN_GRUNN),
+            null,
+            null,
+            innloggetSaksbehandler
+        )
+
+        assertEquals(
+            alleRefusjoner.tilskuddsperiode("mai").refusjonsgrunnlag.sumUtbetaltVarig,
+            maiKorreksjonsutkast.refusjonsgrunnlag.sumUtbetaltVarig
+        )
+
+        val juniKorreksjonsutkast = refusjonService.opprettKorreksjonsutkast(
+            alleRefusjoner.tilskuddsperiode("juni"),
+            setOf(Korreksjonsgrunn.ANNEN_GRUNN),
+            null,
+            null,
+            innloggetSaksbehandler
+        )
+
+        assertEquals(
+            alleRefusjoner.tilskuddsperiode("juni").refusjonsgrunnlag.sumUtbetaltVarig,
+            juniKorreksjonsutkast.refusjonsgrunnlag.sumUtbetaltVarig
+        )
+    }
+
+    @Test
+    fun `en 5g-korrigering vil resultere i samme sum som refusjonen`() {
+        listOf(
+            tilskuddsmelding,
+            tilskuddsmelding.medNyId("februar").medNyPeriode(2024, 2),
+            tilskuddsmelding.medNyId("mars").medNyPeriode(2024, 3),
+            tilskuddsmelding.medNyId("april").medNyPeriode(2024, 4),
+            tilskuddsmelding.medNyId("mai").medNyPeriode(2024, 5),
+            tilskuddsmelding.medNyId("juni").medNyPeriode(2024, 6)
+        ).map { it.opprettRefusjonMedJustertTid() }.forEach { godkjennRefusjonMedJustertTid(it) }
+
+        val alleRefusjoner = refusjonRepository.findAll()
+        val maiKorreksjonsutkast = refusjonService.opprettKorreksjonsutkast(
+            alleRefusjoner.tilskuddsperiode("mai"),
+            setOf(Korreksjonsgrunn.ANNEN_GRUNN),
+            null,
+            null,
+            innloggetSaksbehandler
+        )
+
+        val godkjentMaiKorreksjon = godkjennKorreksjonNullbelopMedJustertTid(maiKorreksjonsutkast)
+        val maiBeregning = godkjentMaiKorreksjon.refusjonsgrunnlag.beregning
+
+        assertNotNull(maiBeregning)
+        assertEquals(
+            alleRefusjoner.tilskuddsperiode("mai").refusjonsgrunnlag.beregning?.refusjonsbeløp,
+            maiBeregning.refusjonsbeløp + godkjentMaiKorreksjon.refusjonsgrunnlag.tidligereUtbetalt
+        )
+
+        val juniKorreksjonsutkast = refusjonService.opprettKorreksjonsutkast(
+            alleRefusjoner.tilskuddsperiode("juni"),
+            setOf(Korreksjonsgrunn.ANNEN_GRUNN),
+            null,
+            null,
+            innloggetSaksbehandler
+        )
+
+        val godkjentJuniKorreksjon = godkjennKorreksjonNullbelopMedJustertTid(juniKorreksjonsutkast)
+        val godkjentJuniBeregning = godkjentJuniKorreksjon.refusjonsgrunnlag.beregning
+
+        assertNotNull(godkjentJuniBeregning)
+
+        assertEquals(
+            alleRefusjoner.tilskuddsperiode("juni").refusjonsgrunnlag.beregning?.refusjonsbeløp,
+            godkjentJuniBeregning.refusjonsbeløp + godkjentJuniKorreksjon.refusjonsgrunnlag.tidligereUtbetalt
+        )
+    }
+
+    private fun gjørInntektoppslagForRefundering(refundering: Refundering, utfortAv: InnloggetBruker) {
         // Sett innhentede inntekter til opptjent i periode
-        refusjon.refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }?.forEach { it.erOpptjentIPeriode = true }
+        refundering.refusjonsgrunnlag.inntektsgrunnlag?.inntekter?.filter { it.erMedIInntektsgrunnlag() }?.forEach { it.erOpptjentIPeriode = true }
         // Bekreft at alle inntektene kun er fra tiltaket
-        refusjonService.endreBruttolønn(refusjon, true, null)
-        refusjonService.gjørBeregning(refusjon, innloggetArbeidsgiver)
-        refusjonRepository.save(refusjon)
+        refusjonService.endreBruttolønn(refundering, true, null, utfortAv)
+        when (refundering) {
+            is Korreksjon -> korreksjonRepository.save(refundering)
+            is Refusjon -> refusjonRepository.save(refundering)
+        }
     }
 
     private fun godkjennRefusjonMedJustertTid(refusjon: Refusjon) {
@@ -132,10 +228,21 @@ class RefusjonVarig5GTest(
         val oppdatertRefusjon = refusjonRepository.findById(refusjon.id).get()
         refusjonService.gjørBedriftKontonummeroppslag(oppdatertRefusjon)
         refusjonService.gjørInntektsoppslag(oppdatertRefusjon, innloggetArbeidsgiver)
-        gjørInntektoppslagForRefusjon(oppdatertRefusjon)
+        gjørInntektoppslagForRefundering(oppdatertRefusjon, innloggetArbeidsgiver)
         val oppdatertRefusjonIgjen = refusjonRepository.findById(oppdatertRefusjon.id).get()
         refusjonService.godkjennForArbeidsgiver(oppdatertRefusjonIgjen, innloggetArbeidsgiver)
         refusjonRepository.save(oppdatertRefusjonIgjen)
+    }
+
+    private fun godkjennKorreksjonNullbelopMedJustertTid(korreksjon: Korreksjon): Korreksjon {
+        val oppdatertKorreksjon = korreksjonRepository.findById(korreksjon.id).get()
+        refusjonService.gjørBedriftKontonummeroppslag(oppdatertKorreksjon)
+        refusjonService.gjørInntektsoppslag(oppdatertKorreksjon, innloggetArbeidsgiver)
+        gjørInntektoppslagForRefundering(oppdatertKorreksjon, innloggetSaksbehandler)
+        val oppdatertKorreksjonIgjen = korreksjonRepository.findById(oppdatertKorreksjon.id).get()
+        refusjonService.gjørBeregning(oppdatertKorreksjonIgjen, innloggetSaksbehandler)
+        oppdatertKorreksjonIgjen.fullførKorreksjonVedOppgjort(innloggetSaksbehandler)
+        return korreksjonRepository.save(oppdatertKorreksjonIgjen)
     }
 
     private fun TilskuddsperiodeGodkjentMelding.opprettRefusjonMedJustertTid(): Refusjon {

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
@@ -237,7 +237,7 @@ class RefusjonVarig5GTest(
     private fun godkjennKorreksjonNullbelopMedJustertTid(korreksjon: Korreksjon): Korreksjon {
         val oppdatertKorreksjon = korreksjonRepository.findById(korreksjon.id).get()
         refusjonService.gjørBedriftKontonummeroppslag(oppdatertKorreksjon)
-        refusjonService.gjørInntektsoppslag(oppdatertKorreksjon, innloggetArbeidsgiver)
+        refusjonService.gjørInntektsoppslag(oppdatertKorreksjon, innloggetSaksbehandler)
         gjørInntektoppslagForRefundering(oppdatertKorreksjon, innloggetSaksbehandler)
         val oppdatertKorreksjonIgjen = korreksjonRepository.findById(oppdatertKorreksjon.id).get()
         refusjonService.gjørBeregning(oppdatertKorreksjonIgjen, innloggetSaksbehandler)


### PR DESCRIPTION
Tidligere har ikke korreksjoner tatt høyde for 5G-grense på varig lønntilskudd
(og nå fireårig lønnstilskudd). Når en korreksjon ble opprettet, ble verdien for
"totalt utbetalt så langt på tiltaket" satt til 0, som i praksis betyr at logikken
som beregner om en sum overskrider 5G hoppes over.

**Man kunne altså opprette en korreksjon på refusjoner som har blitt begrenset
av 5G, og få utbetalt en ubegrenset sum.**

Denne endringen sørger for at "sumUtbetaltVarig" oppdateres for korreksjoner
ved opprettelse.

Videre arbeid vil være å holde åpne korreksjoner oppdatert hver gang en
refusjon sendes inn, slik at man feks ikke kan gå over 5G ved å sende inn en
refusjon rett før man sender inn en korreksjon som var åpnet før innsending.