### PR TITLE
Bugfix for 5g korreksjon

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonService.kt
@@ -161,37 +161,16 @@ class RefusjonService(
                 refundering.tiltakstype()
             )
 
-        val alleInnsendteRefusjonerOgKorreksjonerForTiltaket = (utbetalteRefusjoner + utbetalteKorreksjoner)
+        val alleInnsendteRefusjonerOgKorreksjonerForTiltaket = utbetalteRefusjoner + utbetalteKorreksjoner
 
         val alleUtbetalteForSammeÅr: List<Refundering> = alleInnsendteRefusjonerOgKorreksjonerForTiltaket
             .filter { utbetaltRefundering ->
                 utbetaltRefundering.fraSammeÅrSom(refundering)
             }
 
-        val nyBeregnetSum = alleUtbetalteForSammeÅr
+        return alleUtbetalteForSammeÅr
             .mapNotNull { it.refusjonsgrunnlag.beregning?.refusjonsbeløp }
             .sum()
-
-        // Gammel sum ble beregnet av kun refusjoner, og status "utbetaling feilet" var ikke inkludert
-        val gammelBeregnetSum = alleUtbetalteForSammeÅr
-            .filterIsInstance<Refusjon>()
-            .filter { it.status != RefusjonStatus.UTBETALING_FEILET }
-            .mapNotNull { it.refusjonsgrunnlag.beregning?.refusjonsbeløp }
-            .sum()
-
-        if (nyBeregnetSum != gammelBeregnetSum) {
-            log.warn(
-                "Ny beregning for totalt utbetalt for tiltak avviker fra gammel beregning. Avtalenr: {}," +
-                        "ny sum: {}, gammel sum: {}. Har feilede refusjonsutbetalinger: {}," +
-                        "har korreksjoner: {}",
-                refundering.refusjonsgrunnlag.tilskuddsgrunnlag.avtaleNr,
-                nyBeregnetSum,
-                gammelBeregnetSum,
-                alleUtbetalteForSammeÅr.any { it.status == RefusjonStatus.UTBETALING_FEILET },
-                alleUtbetalteForSammeÅr.any { it is Korreksjon })
-        }
-
-        return gammelBeregnetSum
     }
 
     fun gjørInntektsoppslag(korreksjon: Korreksjon, utfortAv: InnloggetBruker) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonStatus.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonStatus.kt
@@ -18,9 +18,11 @@ enum class RefusjonStatus: RefunderingStatus {
     }
 
     fun ansesSomUtbetalt() = when (this) {
-        KLAR_FOR_INNSENDING, FOR_TIDLIG, ANNULLERT, GODKJENT_MINUSBELØP, KORRIGERT, UTGÅTT -> false
+        KLAR_FOR_INNSENDING, FOR_TIDLIG, ANNULLERT, GODKJENT_MINUSBELØP, UTGÅTT -> false
         SENDT_KRAV, UTBETALT, GODKJENT_NULLBELØP -> true
         // Feilede utbetalinger kan bli rettet opp i Oebs og må derfor anses som utbetalt
         UTBETALING_FEILET -> true
+        // Korrigerte refusjoner må inngå i beregninger, fordi korreksjonene kun utbetaler mellomlegg
+        KORRIGERT -> true
     }
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakrefusjon/refusjon/RefusjonVarig5GTest.kt
@@ -145,7 +145,7 @@ class RefusjonVarig5GTest(
             innloggetSaksbehandler
         )
 
-        val godkjentMaiKorreksjon = godkjennKorreksjonNullbelopMedJustertTid(maiKorreksjonsutkast)
+        val godkjentMaiKorreksjon = godkjennKorreksjonNullbelopMedJustertTid(maiKorreksjonsutkast, alleRefusjoner.tilskuddsperiode("mai"))
         val maiBeregning = godkjentMaiKorreksjon.refusjonsgrunnlag.beregning
 
         assertEquals(
@@ -166,7 +166,7 @@ class RefusjonVarig5GTest(
             innloggetSaksbehandler
         )
 
-        val godkjentJuniKorreksjon = godkjennKorreksjonNullbelopMedJustertTid(juniKorreksjonsutkast)
+        val godkjentJuniKorreksjon = godkjennKorreksjonNullbelopMedJustertTid(juniKorreksjonsutkast, alleRefusjoner.tilskuddsperiode("juni"))
         val godkjentJuniBeregning = godkjentJuniKorreksjon.refusjonsgrunnlag.beregning
 
         assertEquals(
@@ -202,7 +202,7 @@ class RefusjonVarig5GTest(
         refusjonRepository.save(oppdatertRefusjonIgjen)
     }
 
-    private fun godkjennKorreksjonNullbelopMedJustertTid(korreksjon: Korreksjon): Korreksjon {
+    private fun godkjennKorreksjonNullbelopMedJustertTid(korreksjon: Korreksjon, refusjon: Refusjon): Korreksjon {
         val oppdatertKorreksjon = korreksjonRepository.findById(korreksjon.id).get()
         refusjonService.gjørBedriftKontonummeroppslag(oppdatertKorreksjon)
         refusjonService.gjørInntektsoppslag(oppdatertKorreksjon, innloggetSaksbehandler)
@@ -210,6 +210,8 @@ class RefusjonVarig5GTest(
         val oppdatertKorreksjonIgjen = korreksjonRepository.findById(oppdatertKorreksjon.id).get()
         refusjonService.gjørBeregning(oppdatertKorreksjonIgjen, innloggetSaksbehandler)
         oppdatertKorreksjonIgjen.fullførKorreksjonVedOppgjort(innloggetSaksbehandler)
+        refusjon.status = RefusjonStatus.KORRIGERT
+        refusjonRepository.save(refusjon)
         return korreksjonRepository.save(oppdatertKorreksjonIgjen)
     }
 


### PR DESCRIPTION
Brukte fortsatt gammel logikk for å beregne 5G for refusjoner og korreksjoner. Under "prod-test" oppdaget vi en feil der summen hadde for lavt avvik, som skyldtes at refusjoner som hadde status "KORRIGERT" ikke ble tatt med i kalkulasjon av totalt utbetalt for tiltaket.

Det blir ikke riktig, fordi korreksjoner kun utbetaler (eller tilbakekrever) mellomlegget fra den opprinnelige refusjonen.

Sidenote: Det er fortsatt riktig å ignorere den refusjonen som skal korrigeres, så vi beholder logikken med å ignorere denne.